### PR TITLE
feat: allow custom table names via dict or callable

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -122,6 +122,7 @@ Options:
   --tables [unified-cep-only|cep-tables|all]
                                   Which tables to keep in the database after
                                   the import
+  --table-name <original=custom>  Rename a table: --table-name original=custom
   -v, --verbose                   Enables verbose mode.
   -h, --help                      Show this message and exit.
 ```
@@ -168,6 +169,17 @@ The following options are available:
   only the unified CEP table.
 
 
+- __`--table-name`__ **(optional)**
+
+  Allows customizing a table name in the database. Can be used multiple times
+  to rename several tables. The format is `original=custom`, where `original` is the
+  default table name and `custom` is the desired name.
+
+  Example: `--table-name cep_unificado=correios_cep`
+
+  Useful for integrating with projects that follow naming conventions, such as Django.
+
+
 - __`--verbose`__ **(optional)**
 
   Enables verbose mode, which displays DEBUG information useful for troubleshooting
@@ -196,6 +208,13 @@ edne-correios-loader load \
   --dne-source /path/to/dne/dir \
   --database-url mysql+mysqlclient://user:pass@localhost:3306/mydb \
   --tables all
+```
+
+Imports the e-DNE renaming the unified table to `correios_cep`:
+```shell
+edne-correios-loader load \
+  --database-url sqlite:///dne.db \
+  --table-name cep_unificado=correios_cep
 ```
 
 The command output may vary depending on the options used, but it should be
@@ -324,6 +343,11 @@ $ edne-correios-loader query-cep --database-url mysql+mysqlclient://user:pass@lo
 }
 ```
 
+If the unified table was renamed during import, use the `--cep-table-name` option:
+```shell
+$ edne-correios-loader query-cep --database-url sqlite:///dne.db --cep-table-name correios_cep 01001000
+```
+
 
 ### Python API
 
@@ -339,6 +363,9 @@ DneLoader(
   # Path or URL to the ZIP file or directory with e-DNE files (optional)
   # When omitted, the e-DNE will be automatically downloaded from the Correios website
   dne_source="/path/to/dne.zip",
+  # Customize table names in the database (optional)
+  # Accepts a dict or a callable that transforms the names
+  table_names={"cep_unificado": "correios_cep"},
 ).load(
   # define the tables to keep in the database after the import (optional)
   # When omitted, only the unified table is kept
@@ -347,11 +374,23 @@ DneLoader(
 )
 ```
 
+The `table_names` parameter also accepts a callable to transform all names:
+```python
+DneLoader(
+  'sqlite:///dne.db',
+  table_names=lambda name: f"dne_{name}",  # dne_cep_unificado, dne_log_localidade, etc.
+).load()
+```
+
 After the import, CEPs can be queried in the unified table using the `CepQuerier` class:
 ```python
 from edne_correios_loader import CepQuerier
 
-cep_querier = CepQuerier('postgresql://user:pass@localhost:5432/mydb')
+# If the table was renamed, provide the custom name
+cep_querier = CepQuerier(
+  'postgresql://user:pass@localhost:5432/mydb',
+  cep_table_name='correios_cep',  # optional, default: 'cep_unificado'
+)
 cep = cep_querier.query('01319010')
 
 assert cep == {

--- a/README-en.md
+++ b/README-en.md
@@ -4,107 +4,99 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/edne-correios-loader.svg)](https://pypi.org/project/edne-correios-loader)
 [![codecov](https://codecov.io/gh/cauethenorio/edne-correios-loader/graph/badge.svg?token=HP9C86U1LX)](https://codecov.io/gh/cauethenorio/edne-correios-loader)
 
-CLI to download and load the e-DNE Básico from Correios (Brazilian postal service) into a database
-(PostgreSQL, MySQL, SQLite, and others) and create a single table for querying postal codes (CEPs).
+Load all Brazilian postal codes (CEPs) into your database with a single command.
 
----
-
-### [Versão em português 🇧🇷](README.md)
-
-## Features
-
-- Automatically downloads the e-DNE Básico from the Correios website
-- Imports Correios' e-DNE Básico files into a database
-- Creates a unified table for querying postal codes (CEPs)
-- Supports databases like PostgreSQL, MySQL, SQLite, and others
-- Allows for data updates without service interruption
- 
-
-## Purpose
-
-The DNE (National Address Directory) is an official and exclusive database of Correios
-(Brazilian postal service), containing over 900 thousand postal codes from all over Brazil.
-It consists of addressing elements (description of streets, neighborhoods, municipalities,
-villages, hamlets) and Postal Address Codes - CEP.
-
-This database is available in two versions, the __e-DNE Basic__ and the __e-DNE Master__.
-Both contain all the postal codes in Brazil, with addressing elements down to the street section level,
-but they differ in format. The e-DNE Basic is composed of several text files (`.txt`) that need
-to be processed and transferred to a database in order to be queried. On the other hand, the
-e-DNE Master is a database in MS-Access format (`.mdb`) ready for use.
-
-This project automatically downloads the e-DNE Basic from the Correios website, processes the
-text files, and transfers them to a database. It also creates a unified table for querying
-postal codes (not included in the original DNE, where different types of postal codes are stored
-in separate tables) and allows your database to be updated with new versions of the e-DNE,
-released biweekly by Correios.
-
-
-## Installation
-
-If you have [uv](https://docs.astral.sh/uv/) installed, you can run `edne-correios-loader`
-directly without installing:
+The e-DNE (National Address Directory) from Correios (Brazilian postal service) contains over 1.5 million postal codes and is freely available. This tool automatically downloads the latest version, processes the files and loads them into any database (PostgreSQL, MySQL, SQLite, etc.), creating a unified table ready for querying.
 
 ```shell
 uvx edne-correios-loader load --database-url sqlite:///dne.db
 ```
 
-For databases that require additional drivers, such as PostgreSQL, use the `--from` option
-with the corresponding extra:
+---
+
+### [Versão em português 🇧🇷](README.md)
+
+
+## Quick Start
+
+With [uv](https://docs.astral.sh/uv/) installed, run directly without installing:
+
+```shell
+uvx edne-correios-loader load --database-url sqlite:///dne.db
+```
+
+For PostgreSQL:
 
 ```shell
 uvx --from 'edne-correios-loader[postgresql]' edne-correios-loader load \
   --database-url postgresql://user:pass@localhost:5432/mydb
 ```
 
-If you prefer to install the package, `edne-correios-loader` can be installed via `pip`:
+After the import, query CEPs:
+
+```shell
+$ edne-correios-loader query-cep --database-url sqlite:///dne.db 01001000
+{
+  "cep": "01001000",
+  "logradouro": "Praça da Sé",
+  "complemento": null,
+  "bairro": "Sé",
+  "municipio": "São Paulo",
+  "municipio_cod_ibge": 3550308,
+  "uf": "SP",
+  "nome": null
+}
+```
+
+
+## What it does
+
+- Automatically downloads the e-DNE Básico from the Correios website
+- Processes the text files and loads them into a database
+- Creates a unified table for querying postal codes (not included in the original DNE)
+- Supports PostgreSQL, MySQL, SQLite and other databases via SQLAlchemy
+- Allows customizing the names of created tables
+- Updates data without service interruption (atomic transaction)
+- Biweekly updates: just run the command again
+
+
+## Installation
+
+If you prefer to install the package instead of using `uvx`:
 
 ```shell
 pip install edne-correios-loader
 ```
 
-You will also need to install the database driver that will be used. Here are some
-instructions on how to install drivers for the most common databases:
+You will also need to install the database driver that will be used:
 
 ### PostgreSQL
 
-For PostgreSQL, the `psycopg2-binary` driver can be installed using an
-[extra](https://peps.python.org/pep-0508/#extras):
 ```shell
 pip install edne-correios-loader[postgresql]
 ```
 
 If there is no pre-compiled version of `psycopg2` for your operating system and Python version,
-you may need to install some libraries to be able to compile the driver. Another option is to install the
-`pg8000` driver for PostgreSQL, which is written entirely in Python and does not need to be compiled.
+another option is to install the `pg8000` driver, which is written entirely in Python.
 
 ### MySQL
 
-For MySQL, the `mysqlclient` driver can be installed using an
-[extra](https://peps.python.org/pep-0508/#extras):
 ```shell
 pip install edne-correios-loader[mysql]
 ```
 
 ### SQLite
 
-Python already provides the `sqlite3` library for communication with SQLite, so no
-additional instructions are needed.
+Python already provides the `sqlite3` library, so no additional instructions are needed.
 
 ### Others
 
-The `sqlalchemy` library is used for communication with the database, so any database
-supported by it can be used, such as Microsoft SQL Server and Oracle. To install
-the driver for a database not listed here, refer to the SQLAlchemy documentation:
-https://docs.sqlalchemy.org/en/20/dialects/index.html
-
+Any database supported by [SQLAlchemy](https://docs.sqlalchemy.org/en/20/dialects/index.html) can be used, such as Microsoft SQL Server and Oracle.
 
 
 ## Usage
 
 ### Command Line
-
-The data import can be executed via the command line using the `edne-correios-loader load` command.
 
 ```shell
 $ edne-correios-loader load --help
@@ -129,17 +121,16 @@ Options:
 
 #### Options
 
-The following options are available:
 - __`--dne-source`__ **(optional)**
 
   Source of the e-DNE to be imported. It can be:
     - A URL to a ZIP file with the e-DNE
     - The local path to a ZIP file with the e-DNE
     - The local path to a directory containing the e-DNE files
-    
+
   If this option is not provided, the latest e-DNE Basic will be automatically
   downloaded from the Correios website and used as the source.
- 
+
 
 - __`--database-url`__ **(required)**
 
@@ -156,7 +147,7 @@ The following options are available:
 
   More information about the URL format can be found in the
     [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls)
- 
+
 
 - __`--tables`__ **(optional)**
 
@@ -177,7 +168,7 @@ The following options are available:
 
   Example: `--table-name cep_unificado=correios_cep`
 
-  Useful for integrating with projects that follow naming conventions, such as Django.
+  Useful for integrating with projects that follow table naming conventions.
 
 
 - __`--verbose`__ **(optional)**
@@ -187,165 +178,31 @@ The following options are available:
 
 #### Usage Examples
 
-Imports the e-DNE Basic directly from the Correios website to a local SQLite database,
-keeping only the unified table:
+Imports the e-DNE Basic directly from the Correios website to a local SQLite database:
 ```shell
 edne-correios-loader load --database-url sqlite:///dne.db
 ```
 
-Imports the e-DNE Basic from a ZIP file to a local PostgreSQL database, keeping all
-tables with CEPs:
+Same for PostgreSQL:
 ```shell
-edne-correios-loader load \
-  --dne-source /path/to/dne.zip \
-  --database-url postgresql://user:pass@localhost:5432/mydb \
-  --tables cep-tables
+edne-correios-loader load --database-url postgresql://user:pass@localhost:5432/mydb
 ```
 
-Imports the e-DNE Basic from a directory to a local MySQL database, keeping all tables:
-```shell
-edne-correios-loader load \
-  --dne-source /path/to/dne/dir \
-  --database-url mysql+mysqlclient://user:pass@localhost:3306/mydb \
-  --tables all
-```
-
-Imports the e-DNE renaming the unified table to `correios_cep`:
+Renaming the unified table:
 ```shell
 edne-correios-loader load \
   --database-url sqlite:///dne.db \
   --table-name cep_unificado=correios_cep
 ```
 
-The command output may vary depending on the options used, but it should be
-similar to the following:
-```
-Starting DNE Correios Loader v1.1.0
-
-Connecting to database...
-
-Resolving DNE source...
-
-No DNE source provided, the latest DNE will be downloaded from Correios website
-Downloading DNE file  [####################################]  100%
-
-Creating tables:
-- cep_unificado
-- log_localidade
-- log_bairro
-- log_cpc
-- log_logradouro
-- log_grande_usuario
-- log_unid_oper
-
-Cleaning tables
-
-Populating table log_localidade
-  Reading LOG_LOCALIDADE.TXT
-  Inserted 11219 rows into table "log_localidade"
-
-Populating table log_bairro
-  Reading LOG_BAIRRO.TXT
-  Inserted 64456 rows into table "log_bairro"
-
-Populating table log_cpc
-  Reading LOG_CPC.TXT
-  Inserted 2133 rows into table "log_cpc"
-
-Populating table log_logradouro
-  Reading LOG_LOGRADOURO_RS.TXT
-  Reading LOG_LOGRADOURO_RR.TXT
-  Reading LOG_LOGRADOURO_SC.TXT
-  Reading LOG_LOGRADOURO_SP.TXT
-  Reading LOG_LOGRADOURO_SE.TXT
-  Reading LOG_LOGRADOURO_PI.TXT
-  Reading LOG_LOGRADOURO_MS.TXT
-  Reading LOG_LOGRADOURO_AP.TXT
-  Reading LOG_LOGRADOURO_MG.TXT
-  Reading LOG_LOGRADOURO_MT.TXT
-  Reading LOG_LOGRADOURO_AC.TXT
-  Reading LOG_LOGRADOURO_MA.TXT
-  Reading LOG_LOGRADOURO_TO.TXT
-  Reading LOG_LOGRADOURO_AL.TXT
-  Reading LOG_LOGRADOURO_CE.TXT
-  Reading LOG_LOGRADOURO_BA.TXT
-  Reading LOG_LOGRADOURO_AM.TXT
-  Reading LOG_LOGRADOURO_ES.TXT
-  Reading LOG_LOGRADOURO_PR.TXT
-  Reading LOG_LOGRADOURO_PE.TXT
-  Reading LOG_LOGRADOURO_GO.TXT
-  Reading LOG_LOGRADOURO_RN.TXT
-  Reading LOG_LOGRADOURO_RO.TXT
-  Reading LOG_LOGRADOURO_DF.TXT
-  Reading LOG_LOGRADOURO_RJ.TXT
-  Reading LOG_LOGRADOURO_PB.TXT
-  Reading LOG_LOGRADOURO_PA.TXT
-  Inserted 1236944 rows into table "log_logradouro"
-
-Populating table log_grande_usuario
-  Reading LOG_GRANDE_USUARIO.TXT
-  Inserted 18967 rows into table "log_grande_usuario"
-
-Populating table log_unid_oper
-  Reading LOG_UNID_OPER.TXT
-  Inserted 12534 rows into table "log_unid_oper"
-
-Populating unified CEP table
-  Populating unified CEP table with logradouros data
-    Inserted 1236944 CEPs from logradouros into table cep_unificado
-  Populating unified CEP table with localidades data
-    Inserted 4974 CEPs from localidades into table cep_unificado
-  Populating unified CEP table with localidades subordinadas data
-    Inserted 5311 CEPs from localidades subordinadas into table cep_unificado
-  Populating unified CEP table with normalized CPC data
-    Inserted 2133 CEPs from CPC into table cep_unificado
-  Populating unified CEP table with normalized grandes usuários data
-    Inserted 18967 CEPs from grandes usuários into table cep_unificado
-  Populating unified CEP table with normalized unidades operacionais data
-    Inserted 12534 CEPs from unidades operacionais into table cep_unificado
-  Inserted 1280863 rows into table "cep_unificado"
-
-Dropping tables
-  Dropping table log_faixa_uop
-  Dropping table log_var_log
-  Dropping table log_unid_oper
-  Dropping table log_num_sec
-  Dropping table log_grande_usuario
-  Dropping table log_var_bai
-  Dropping table log_logradouro
-  Dropping table log_faixa_cpc
-  Dropping table log_faixa_bairro
-  Dropping table log_var_loc
-  Dropping table log_faixa_localidade
-  Dropping table log_cpc
-  Dropping table log_bairro
-  Dropping table log_localidade
-  Dropping table log_faixa_uf
-  Dropping table ect_pais
-```
-
 #### CEP Query
 
 After the import, it's possible to check if the data was imported correctly by querying
-CEPs in the unified table using the command `edne-correios-loader query-cep`. Example:
-
-```shell
-$ edne-correios-loader query-cep --database-url mysql+mysqlclient://user:pass@localhost:3306/mydb 01001000
-{
-  "cep": "01001000",
-  "logradouro": "Praça da Sé",
-  "complemento": null,
-  "bairro": "Sé",
-  "municipio": "São Paulo",
-  "municipio_cod_ibge": 3550308,
-  "uf": "SP",
-  "nome": null
-}
-```
+CEPs in the unified table using the command `edne-correios-loader query-cep`.
 
 If the unified table was renamed during import, use the `--cep-table-name` option:
 ```shell
-$ edne-correios-loader query-cep --database-url sqlite:///dne.db --cep-table-name correios_cep 01001000
+edne-correios-loader query-cep --database-url sqlite:///dne.db --cep-table-name correios_cep 01001000
 ```
 
 
@@ -411,12 +268,8 @@ Every two weeks, Correios updates the e-DNE with new postal codes. To update you
 simply run the `load` command again. The latest e-DNE will be automatically downloaded from
 the Correios website.
 
-The command will delete the data from all e-DNE tables and import the data from the new e-DNE.
-After the import, the unified table is repopulated with the new data.
-
 The whole process is executed inside a transaction, so other clients connected to the database
 will continue to have access to the old data while the update is being executed.
-
 If something goes wrong during the update, the transaction will be rolled back and the old data will be preserved.
 
 
@@ -436,7 +289,7 @@ To run the tests, you need to have [Docker](https://www.docker.com/) and
 3. Execute the tests using `uv`:
   ```shell
   uv run pytest tests
-  ``` 
+  ```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Options:
   --tables [unified-cep-only|cep-tables|all]
                                   Which tables to keep in the database after
                                   the import
+  --table-name <original=custom>  Rename a table: --table-name original=custom
   -v, --verbose                   Enables verbose mode.
   -h, --help                      Show this message and exit.
 ```
@@ -168,6 +169,17 @@ As seguintes opções estão disponíveis:
   apenas a tabela unificada de CEPs.
 
 
+- __`--table-name`__ **(opcional)**
+
+  Permite personalizar o nome de uma tabela no banco de dados. Pode ser utilizado múltiplas
+  vezes para renomear várias tabelas. O formato é `original=custom`, onde `original` é o
+  nome padrão da tabela e `custom` é o nome desejado.
+
+  Exemplo: `--table-name cep_unificado=correios_cep`
+
+  Útil para integrar com projetos que seguem convenções de nomeação das tabelas.
+
+
 - __`--verbose`__ **(opcional)**
 
   Habilita o modo verboso, que exibe informações de DEBUG úteis para resolver problemas
@@ -197,6 +209,13 @@ edne-correios-loader load \
   --dne-source /path/to/dne/dir \
   --database-url mysql+mysqlclient://user:pass@localhost:3306/mydb \
   --tables all
+```
+
+Importa o e-DNE renomeando a tabela unificada para `correios_cep`:
+```shell
+edne-correios-loader load \
+  --database-url sqlite:///dne.db \
+  --table-name cep_unificado=correios_cep
 ```
 
 A saída do comando varia conforme as opções utilizadas, mas deve ser
@@ -325,6 +344,11 @@ $ edne-correios-loader query-cep --database-url mysql+mysqlclient://user:pass@lo
 }
 ```
 
+Se a tabela unificada foi renomeada durante a importação, use a opção `--cep-table-name`:
+```shell
+$ edne-correios-loader query-cep --database-url sqlite:///dne.db --cep-table-name correios_cep 01001000
+```
+
 
 ### API Python
 
@@ -340,6 +364,9 @@ DneLoader(
   # Caminho ou URL para o arquivo ZIP ou diretório com os arquivos do e-DNE (opcional)
   # Quando omitido, o e-DNE será baixado automaticamente do site dos Correios
   dne_source="/path/to/dne.zip",
+  # Personaliza os nomes das tabelas no banco de dados (opcional)
+  # Aceita um dict ou um callable que transforma os nomes
+  table_names={"cep_unificado": "correios_cep"},
 ).load(
   # Quais tabelas manter no banco de dados após a importação (opcional)
   # quando omitido apenas a tabela unificada é mantida
@@ -348,11 +375,23 @@ DneLoader(
 )
 ```
 
+O parâmetro `table_names` também aceita um callable para transformar todos os nomes:
+```python
+DneLoader(
+  'sqlite:///dne.db',
+  table_names=lambda name: f"dne_{name}",  # dne_cep_unificado, dne_log_localidade, etc.
+).load()
+```
+
 Após a importação, os CEPs podem ser consultados na tabela unificada através da classe `CepQuerier`:
 ```python
 from edne_correios_loader import CepQuerier
 
-cep_querier = CepQuerier('postgresql://user:pass@localhost:5432/mydb')
+# Se a tabela foi renomeada, informe o nome personalizado
+cep_querier = CepQuerier(
+  'postgresql://user:pass@localhost:5432/mydb',
+  cep_table_name='correios_cep',  # opcional, padrão: 'cep_unificado'
+)
 cep = cep_querier.query('01319010')
 
 assert cep == {

--- a/README.md
+++ b/README.md
@@ -4,107 +4,99 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/edne-correios-loader.svg)](https://pypi.org/project/edne-correios-loader)
 [![codecov](https://codecov.io/gh/cauethenorio/edne-correios-loader/graph/badge.svg?token=HP9C86U1LX)](https://codecov.io/gh/cauethenorio/edne-correios-loader)
 
-Programa de linha de comando para baixar e carregar o e-DNE Básico dos Correios para um banco de
-dados (PostgreSQL, MySQL, SQLite e outros) e criar uma tabela única para consulta de CEPs.
+Carregue todos os CEPs do Brasil no seu banco de dados com um único comando.
 
----
-
-### [English version 🇺🇸](README-en.md)
-
-## Funcionalidades
-
-- Baixa automaticamente o e-DNE Básico do site dos Correios
-- Carrega os dados do e-DNE para um banco de dados
-- Cria uma tabela unificada para consulta de CEPs
-- Suporta os bancos de dados PostgreSQL, MySQL, SQLite entre outros
-- Permite atualização dos dados sem interrupção do serviço
- 
-
-## Propósito
-
-O DNE (Diretório Nacional de Endereços) é um banco de dados oficial e exclusivo dos Correios,
-que contém mais de 900 mil CEPs de todo o Brasil, constituído de elementos de endereçamento
-(descrição de logradouros, bairros, municípios, vilas, povoados) e Códigos de Endereçamento
-Postal - CEP.
-
-Esse banco de dados é disponibilizado em duas versões, o __e-DNE Básico__ e o __e-DNE Máster__.
-Ambas contêm todos os CEPs do Brasil, com elementos de endereçamento até nível de seção
-de logradouro, porém diferem no formato. O e-DNE Básico é composto por vários arquivos de texto
-(`.txt`) que precisam ser processados e transferidos para um banco de dados para poderem ser
-consultados. Já o e-DNE Máster é um banco de dados no formato MS-Access (`.mdb`) pronto para uso.
-
-Esse projeto baixa automaticamente o e-DNE Básico do site dos Correios, processa os arquivos
-de texto e os transfere para um banco de dados. Ele também cria uma tabela unificada para
-consulta de CEPs (não inclusa no DNE original, onde CEPs de diferentes tipos ficam em tabelas
-separadas) e permite atualizar sua base com novas versões do e-DNE, lançadas quinzenalmente
-pelos Correios.
-
-
-## Instalação
-
-Se você tem [uv](https://docs.astral.sh/uv/) instalado, pode executar o `edne-correios-loader`
-diretamente sem precisar instalar:
+O e-DNE (Diretório Nacional de Endereços) dos Correios contém mais de 1,5 milhão de CEPs e está disponível gratuitamente. Esta ferramenta baixa automaticamente a versão mais recente, processa os arquivos e carrega em qualquer banco de dados (PostgreSQL, MySQL, SQLite, etc.), criando uma tabela unificada pronta para consulta.
 
 ```shell
 uvx edne-correios-loader load --database-url sqlite:///dne.db
 ```
 
-Para bancos de dados que necessitam de drivers adicionais, como PostgreSQL, use a opção
-`--from` com o extra correspondente:
+---
+
+### [English version 🇺🇸](README-en.md)
+
+
+## Quick Start
+
+Com [uv](https://docs.astral.sh/uv/) instalado, execute diretamente sem precisar instalar:
+
+```shell
+uvx edne-correios-loader load --database-url sqlite:///dne.db
+```
+
+Para PostgreSQL:
 
 ```shell
 uvx --from 'edne-correios-loader[postgresql]' edne-correios-loader load \
   --database-url postgresql://user:pass@localhost:5432/mydb
 ```
 
-Caso prefira instalar o pacote, o `edne-correios-loader` pode ser instalado através do `pip`:
+Após a importação, consulte CEPs:
+
+```shell
+$ edne-correios-loader query-cep --database-url sqlite:///dne.db 01001000
+{
+  "cep": "01001000",
+  "logradouro": "Praça da Sé",
+  "complemento": null,
+  "bairro": "Sé",
+  "municipio": "São Paulo",
+  "municipio_cod_ibge": 3550308,
+  "uf": "SP",
+  "nome": null
+}
+```
+
+
+## O que faz
+
+- Baixa automaticamente o e-DNE Básico do site dos Correios
+- Processa os arquivos de texto e carrega em um banco de dados
+- Cria uma tabela unificada para consulta de CEPs (não inclusa no DNE original)
+- Suporta PostgreSQL, MySQL, SQLite e outros bancos via SQLAlchemy
+- Permite personalizar os nomes das tabelas criadas
+- Atualiza os dados sem interrupção do serviço (transação atômica)
+- Atualizações quinzenais: basta rodar o comando novamente
+
+
+## Instalação
+
+Caso prefira instalar o pacote ao invés de usar `uvx`:
 
 ```shell
 pip install edne-correios-loader
 ```
 
-Também será necessário instalar o driver do banco de dados que será utilizado. Aqui estão algumas
-instruções de como instalar os drivers para os bancos de dados mais comuns:
+Também será necessário instalar o driver do banco de dados que será utilizado:
 
 ### PostgreSQL
 
-Para o PostgreSQL, o driver `psycopg2-binary` pode ser instalado utilizando um
-[extra](https://peps.python.org/pep-0508/#extras):
 ```shell
 pip install edne-correios-loader[postgresql]
 ```
 
 Se não houver uma versão compilada do `psycopg2` para seu sistema operacional e versão do python,
-você precisará instalar algumas bibliotecas para poder compilar o driver. Outra opção é instalar o
-driver `pg8000` para o PostgreSQL, que é escrito totalmente em Python e não precisa ser compilado.
+outra opção é instalar o driver `pg8000`, escrito totalmente em Python.
 
 ### MySQL
 
-Para o MySQL, o driver `mysqlclient` pode ser instalado utilizando um
-[extra](https://peps.python.org/pep-0508/#extras):
 ```shell
 pip install edne-correios-loader[mysql]
 ```
 
 ### SQLite
 
-O Python já disponibiliza a biblioteca `sqlite3` para comunicação com o SQLite, portanto não é
-necessária nenhuma instrução adicional.
+O Python já disponibiliza a biblioteca `sqlite3`, não é necessária nenhuma instrução adicional.
 
 ### Outros
 
-A biblioteca `sqlalchemy` é utilizada para comunicação com o banco de dados, portanto qualquer banco
-de dados suportado por ela pode ser utilizado, como o Microsoft SQL Server e Oracle. Para instalar
-o driver de um banco de dados não listado aqui, consulte a documentação do SQLAlchemy:
-https://docs.sqlalchemy.org/en/20/dialects/index.html
+Qualquer banco de dados suportado pelo [SQLAlchemy](https://docs.sqlalchemy.org/en/20/dialects/index.html) pode ser utilizado, como Microsoft SQL Server e Oracle.
 
 
 ## Utilização
 
 ### Linha de comando
-
-A importação dos dados pode ser executada através da linha de comando, com o
-comando `edne-correios-loader load`.
 
 ```shell
 $ edne-correios-loader load --help
@@ -129,17 +121,16 @@ Options:
 
 #### Opções
 
-As seguintes opções estão disponíveis:
 - __`--dne-source`__ **(opcional)**
 
   Origem do e-DNE a ser importado. Pode ser:
     - Uma URL apontando para um arquivo ZIP com o e-DNE
     - O caminho local para um arquivo ZIP com o e-DNE
     - O caminho local para um diretório contendo os arquivos do e-DNE
-    
+
   Se essa opção não for informada, o último e-DNE Básico disponível no site dos
   Correios será baixado automaticamente e utilizado como fonte.
- 
+
 
 - __`--database-url`__ **(obrigatório)**
 
@@ -156,7 +147,7 @@ As seguintes opções estão disponíveis:
 
   Mais informações sobre o formato da URL podem ser encontradas na documentação do
     [SQLAlchemy](https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls)
- 
+
 
 - __`--tables`__ **(opcional)**
 
@@ -187,166 +178,31 @@ As seguintes opções estão disponíveis:
 
 #### Exemplos de uso
 
-Importa o e-DNE Básico direto do site dos correios para um banco de dados SQLite local,
-mantendo apenas a tabela unificada:
+Importa o e-DNE Básico direto do site dos Correios para um banco de dados SQLite local:
 ```shell
 edne-correios-loader load --database-url sqlite:///dne.db
 ```
 
-Importa o e-DNE Básico de um arquivo ZIP para um banco de dados PostgreSQL local, mantendo
-todas as tabelas com CEPs:
+O mesmo para PostgreSQL:
 ```shell
-edne-correios-loader load \
-  --dne-source /path/to/dne.zip \
-  --database-url postgresql://user:pass@localhost:5432/mydb \
-  --tables cep-tables
+edne-correios-loader load --database-url postgresql://user:pass@localhost:5432/mydb
 ```
 
-Importa o e-DNE Básico de um diretório para um banco de dados MySQL local, mantendo todas
-as tabelas:
-```shell
-edne-correios-loader load \
-  --dne-source /path/to/dne/dir \
-  --database-url mysql+mysqlclient://user:pass@localhost:3306/mydb \
-  --tables all
-```
-
-Importa o e-DNE renomeando a tabela unificada para `correios_cep`:
+Renomeando a tabela unificada:
 ```shell
 edne-correios-loader load \
   --database-url sqlite:///dne.db \
   --table-name cep_unificado=correios_cep
 ```
 
-A saída do comando varia conforme as opções utilizadas, mas deve ser
-parecida com o seguinte:
-```
-Starting DNE Correios Loader v1.1.0
-
-Connecting to database...
-
-Resolving DNE source...
-
-No DNE source provided, the latest DNE will be downloaded from Correios website
-Downloading DNE file  [####################################]  100%
-
-Creating tables:
-- cep_unificado
-- log_localidade
-- log_bairro
-- log_cpc
-- log_logradouro
-- log_grande_usuario
-- log_unid_oper
-
-Cleaning tables
-
-Populating table log_localidade
-  Reading LOG_LOCALIDADE.TXT
-  Inserted 11219 rows into table "log_localidade"
-
-Populating table log_bairro
-  Reading LOG_BAIRRO.TXT
-  Inserted 64456 rows into table "log_bairro"
-
-Populating table log_cpc
-  Reading LOG_CPC.TXT
-  Inserted 2133 rows into table "log_cpc"
-
-Populating table log_logradouro
-  Reading LOG_LOGRADOURO_RS.TXT
-  Reading LOG_LOGRADOURO_RR.TXT
-  Reading LOG_LOGRADOURO_SC.TXT
-  Reading LOG_LOGRADOURO_SP.TXT
-  Reading LOG_LOGRADOURO_SE.TXT
-  Reading LOG_LOGRADOURO_PI.TXT
-  Reading LOG_LOGRADOURO_MS.TXT
-  Reading LOG_LOGRADOURO_AP.TXT
-  Reading LOG_LOGRADOURO_MG.TXT
-  Reading LOG_LOGRADOURO_MT.TXT
-  Reading LOG_LOGRADOURO_AC.TXT
-  Reading LOG_LOGRADOURO_MA.TXT
-  Reading LOG_LOGRADOURO_TO.TXT
-  Reading LOG_LOGRADOURO_AL.TXT
-  Reading LOG_LOGRADOURO_CE.TXT
-  Reading LOG_LOGRADOURO_BA.TXT
-  Reading LOG_LOGRADOURO_AM.TXT
-  Reading LOG_LOGRADOURO_ES.TXT
-  Reading LOG_LOGRADOURO_PR.TXT
-  Reading LOG_LOGRADOURO_PE.TXT
-  Reading LOG_LOGRADOURO_GO.TXT
-  Reading LOG_LOGRADOURO_RN.TXT
-  Reading LOG_LOGRADOURO_RO.TXT
-  Reading LOG_LOGRADOURO_DF.TXT
-  Reading LOG_LOGRADOURO_RJ.TXT
-  Reading LOG_LOGRADOURO_PB.TXT
-  Reading LOG_LOGRADOURO_PA.TXT
-  Inserted 1236944 rows into table "log_logradouro"
-
-Populating table log_grande_usuario
-  Reading LOG_GRANDE_USUARIO.TXT
-  Inserted 18967 rows into table "log_grande_usuario"
-
-Populating table log_unid_oper
-  Reading LOG_UNID_OPER.TXT
-  Inserted 12534 rows into table "log_unid_oper"
-
-Populating unified CEP table
-  Populating unified CEP table with logradouros data
-    Inserted 1236944 CEPs from logradouros into table cep_unificado
-  Populating unified CEP table with localidades data
-    Inserted 4974 CEPs from localidades into table cep_unificado
-  Populating unified CEP table with localidades subordinadas data
-    Inserted 5311 CEPs from localidades subordinadas into table cep_unificado
-  Populating unified CEP table with normalized CPC data
-    Inserted 2133 CEPs from CPC into table cep_unificado
-  Populating unified CEP table with normalized grandes usuários data
-    Inserted 18967 CEPs from grandes usuários into table cep_unificado
-  Populating unified CEP table with normalized unidades operacionais data
-    Inserted 12534 CEPs from unidades operacionais into table cep_unificado
-  Inserted 1280863 rows into table "cep_unificado"
-
-Dropping tables
-  Dropping table log_faixa_uop
-  Dropping table log_var_log
-  Dropping table log_unid_oper
-  Dropping table log_num_sec
-  Dropping table log_grande_usuario
-  Dropping table log_var_bai
-  Dropping table log_logradouro
-  Dropping table log_faixa_cpc
-  Dropping table log_faixa_bairro
-  Dropping table log_var_loc
-  Dropping table log_faixa_localidade
-  Dropping table log_cpc
-  Dropping table log_bairro
-  Dropping table log_localidade
-  Dropping table log_faixa_uf
-  Dropping table ect_pais
-```
-
 #### Consulta de CEPs
 
 Após a importação, é possível checar se os dados foram importados corretamente consultando
-CEPs na tabela unificada através do comando `edne-correios-loader query-cep`. Exemplo:
-
-```shell
-$ edne-correios-loader query-cep --database-url mysql+mysqlclient://user:pass@localhost:3306/mydb 01001000
-{
-  "cep": "01001000",
-  "logradouro": "Praça da Sé",
-  "complemento": null,
-  "bairro": "Sé",
-  "municipio": "São Paulo",
-  "municipio_cod_ibge": 3550308,
-  "uf": "SP",
-  "nome": null
-}
-```
+CEPs na tabela unificada através do comando `edne-correios-loader query-cep`.
 
 Se a tabela unificada foi renomeada durante a importação, use a opção `--cep-table-name`:
 ```shell
-$ edne-correios-loader query-cep --database-url sqlite:///dne.db --cep-table-name correios_cep 01001000
+edne-correios-loader query-cep --database-url sqlite:///dne.db --cep-table-name correios_cep 01001000
 ```
 
 
@@ -412,12 +268,8 @@ Quinzenalmente os Correios atualizam o e-DNE com novos CEPs. Para atualizar sua 
 basta executar novamente o comando `load`. O e-DNE mais recente será baixado
 automaticamente do site dos Correios.
 
-O comando irá apagar os dados de todas as tabelas do e-DNE e importar os dados do novo e-DNE.
-Após a importação, a tabela unificada é repopulada com os novos dados.
-
 Todo o processo é executado em uma transação, portanto, outros clientes conectados no banco
 continuarão tendo acesso aos dados antigos enquanto a atualização é executada.
-
 Se algo der errado durante a atualização, a transação será desfeita e os dados antigos serão mantidos.
 
 
@@ -437,7 +289,7 @@ Para executar os testes, é necessário a instalação do [Docker](https://www.d
 3. Execute os testes usando o `uv`:
   ```shell
   uv run pytest tests
-  ``` 
+  ```
 
 ## Licença
 

--- a/src/edne_correios_loader/__init__.py
+++ b/src/edne_correios_loader/__init__.py
@@ -1,3 +1,4 @@
 from .cep_querier import CepQuerier  # noqa: F401
 from .loader import DneLoader  # noqa: F401
 from .table_set import TableSetEnum  # noqa: F401
+from .tables import TableNameResolver  # noqa: F401

--- a/src/edne_correios_loader/cep_querier.py
+++ b/src/edne_correios_loader/cep_querier.py
@@ -1,13 +1,18 @@
 from sqlalchemy import create_engine
 
-from .tables import metadata
+from .tables import build_metadata, get_table
 
 
 class CepQuerier:
-    cep_table = metadata.tables["cep_unificado"]
-
-    def __init__(self, database_url: str):
+    def __init__(self, database_url: str, cep_table_name: str | None = None):
         self.engine = create_engine(database_url, echo=False)
+
+        if cep_table_name:
+            metadata = build_metadata({"cep_unificado": cep_table_name})
+        else:
+            metadata = build_metadata()
+
+        self.cep_table = get_table(metadata, "cep_unificado")
 
     def query(self, cep: str) -> dict | None:
         cep = cep.replace("-", "").strip()

--- a/src/edne_correios_loader/cli/__init__.py
+++ b/src/edne_correios_loader/cli/__init__.py
@@ -173,9 +173,7 @@ def query_cep(database_url, cep_table_name, cep):
     Query a CEP from the database to ensure it was correctly populated.
     """
     try:
-        cep_address = CepQuerier(
-            database_url, cep_table_name=cep_table_name
-        ).query(cep)
+        cep_address = CepQuerier(database_url, cep_table_name=cep_table_name).query(cep)
     except Exception as e:
         logger.error(e)  # noqa: TRY400
         sys.exit(1)

--- a/src/edne_correios_loader/cli/__init__.py
+++ b/src/edne_correios_loader/cli/__init__.py
@@ -14,6 +14,7 @@ from edne_correios_loader.loader import logger as loader_logger
 from edne_correios_loader.resolver import DneResolver
 from edne_correios_loader.resolver import logger as resolver_logger
 from edne_correios_loader.table_set import TableSetEnum
+from edne_correios_loader.tables import DEFAULT_TABLE_NAMES
 from edne_correios_loader.unified_table import logger as unified_table_logger
 
 from .logger import add_verbose_option
@@ -46,6 +47,53 @@ class DneLoaderWithProgress(DneLoader):
     DneResolver = DneResolverWithDownloadProgress
 
 
+class TableNameParamType(click.ParamType):
+    """
+    Click parameter type for --table-name key=value pairs.
+    """
+
+    name = "key=value"
+
+    def convert(self, value, param, ctx):
+        if "=" not in value:
+            self.fail(
+                f"Expected format 'original=custom', got '{value}'",
+                param,
+                ctx,
+            )
+
+        key, _, custom = value.partition("=")
+        key = key.strip()
+        custom = custom.strip()
+
+        if not key or not custom:
+            self.fail(
+                f"Expected format 'original=custom', got '{value}'",
+                param,
+                ctx,
+            )
+
+        if key not in DEFAULT_TABLE_NAMES:
+            self.fail(
+                f"Unknown table name '{key}'. "
+                f"Valid names: {', '.join(DEFAULT_TABLE_NAMES)}",
+                param,
+                ctx,
+            )
+
+        return (key, custom)
+
+
+def parse_table_names(table_name):
+    """
+    Build table name mapping from --table-name pairs.
+    """
+    if not table_name:
+        return None
+
+    return dict(table_name)
+
+
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__, prog_name="DNE Correios Loader")
 def edne_correios_loader(): ...  # pragma: no cover
@@ -74,10 +122,17 @@ def edne_correios_loader(): ...  # pragma: no cover
     help="Which tables to keep in the database after the import",
     default="unified-cep-only",
 )
+@click.option(
+    "--table-name",
+    type=TableNameParamType(),
+    multiple=True,
+    help="Rename a table: --table-name original=custom",
+    metavar="<original=custom>",
+)
 @add_verbose_option(
     [logger, loader_logger, resolver_logger, dbwriter_logger, unified_table_logger]
 )
-def load(dne_source, database_url, tables, verbose):
+def load(dne_source, database_url, tables, table_name, verbose):
     """
     Load DNE data into a database.
     """
@@ -85,9 +140,11 @@ def load(dne_source, database_url, tables, verbose):
     click.echo(click.style(f"Starting DNE Correios Loader v{__version__}", bold=True))
 
     try:
-        DneLoaderWithProgress(database_url, dne_source=dne_source).load(
-            table_set=TableSetEnum(tables)
-        )
+        table_names = parse_table_names(table_name)
+
+        DneLoaderWithProgress(
+            database_url, dne_source=dne_source, table_names=table_names
+        ).load(table_set=TableSetEnum(tables))
     except Exception as e:
         if verbose:
             logger.exception(e)  # noqa: TRY401
@@ -104,14 +161,21 @@ def load(dne_source, database_url, tables, verbose):
     required=True,
     metavar="<url>",
 )
+@click.option(
+    "--cep-table-name",
+    help="Custom name for the unified CEP table",
+    metavar="<name>",
+)
 @click.argument("cep")
 @edne_correios_loader.command()
-def query_cep(database_url, cep):
+def query_cep(database_url, cep_table_name, cep):
     """
     Query a CEP from the database to ensure it was correctly populated.
     """
     try:
-        cep_address = CepQuerier(database_url).query(cep)
+        cep_address = CepQuerier(
+            database_url, cep_table_name=cep_table_name
+        ).query(cep)
     except Exception as e:
         logger.error(e)  # noqa: TRY400
         sys.exit(1)

--- a/src/edne_correios_loader/dbwriter.py
+++ b/src/edne_correios_loader/dbwriter.py
@@ -4,7 +4,7 @@ from graphlib import TopologicalSorter
 
 import sqlalchemy as sa
 
-from .tables import metadata
+from .tables import metadata as default_metadata
 from .unified_table import populate_unified_table
 
 logger = logging.getLogger(__name__)
@@ -13,11 +13,11 @@ logger = logging.getLogger(__name__)
 class DneDatabaseWriter:
     engine: sa.Engine
     connection: sa.Connection
-    metadata: sa.MetaData = metadata
     insert_buffer_size = 1000
 
-    def __init__(self, database_url: str):
+    def __init__(self, database_url: str, metadata: sa.MetaData = default_metadata):
         self.engine = sa.create_engine(database_url, echo=False)
+        self.metadata = metadata
 
     def __enter__(self):
         logger.info("Connecting to database...", extra={"indentation": 0})
@@ -39,7 +39,7 @@ class DneDatabaseWriter:
         tables_names = "\n".join([f"- {t}" for t in tables])
 
         logger.info("Creating tables:\n%s", tables_names, extra={"indentation": 0})
-        metadata.create_all(self.engine, tables=metadata_tables)
+        self.metadata.create_all(self.engine, tables=metadata_tables)
 
     def clean_tables(self, tables: list[str]):
         logger.info("Cleaning tables", extra={"indentation": 0})
@@ -100,7 +100,7 @@ class DneDatabaseWriter:
 
     def populate_unified_table(self):
         logger.info("Populating unified CEP table", extra={"indentation": 0})
-        populate_unified_table(self.connection)
+        populate_unified_table(self.connection, self.metadata)
 
     @staticmethod
     def find_self_referencing_fks(table) -> str | None:

--- a/src/edne_correios_loader/loader.py
+++ b/src/edne_correios_loader/loader.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from .dbwriter import DneDatabaseWriter
 from .resolver import DneResolver
 from .table_set import TableSetEnum, get_table_files_glob
+from .tables import TableNameResolver, build_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -23,23 +24,30 @@ class DneLoader:
         database_url: str,
         *,
         dne_source: str | None = None,
+        table_names: TableNameResolver | None = None,
     ):
         self.database_url = database_url
         self.dne_source = dne_source
+        self.metadata = build_metadata(table_names)
 
     def load(self, table_set: TableSetEnum = TableSetEnum.UNIFIED_CEP_ONLY):
         # connect to database to ensure the URL is valid
         # connection will be closed when the context manager exits
-        with self.DneDatabaseWriter(self.database_url) as database_writer:
+        with self.DneDatabaseWriter(
+            self.database_url, self.metadata
+        ) as database_writer:
             # now that we know the URL is valid, download/extract the DNE file
             # temp files will be removed when the context manager exits
             with self.DneResolver(self.dne_source) as dne_path:
                 # all good, let's start by ensuring the tables exist and are empty
-                database_writer.create_tables(table_set.to_populate)
-                database_writer.clean_tables(table_set.to_populate)
+                tables_to_populate = table_set.to_populate(self.metadata)
+                tables_to_drop = table_set.to_drop(self.metadata)
 
-                for table in table_set.to_populate:
-                    files_glob = get_table_files_glob(table)
+                database_writer.create_tables(tables_to_populate)
+                database_writer.clean_tables(tables_to_populate)
+
+                for table in tables_to_populate:
+                    files_glob = get_table_files_glob(table, self.metadata)
 
                     if files_glob:
                         files = dne_path.glob(files_glob)
@@ -49,7 +57,7 @@ class DneLoader:
                         database_writer.populate_table(table, data)
 
             database_writer.populate_unified_table()
-            database_writer.drop_tables(table_set.to_drop)
+            database_writer.drop_tables(tables_to_drop)
 
 
 class TableFilesReader:

--- a/src/edne_correios_loader/resolver.py
+++ b/src/edne_correios_loader/resolver.py
@@ -157,7 +157,7 @@ class DneResolver:
 
     def resolve_dir_source(self, dne_dir: Path) -> Path:
         # assert all the data files are present
-        for table in TableSetEnum.ALL_TABLES.to_populate:
+        for table in TableSetEnum.ALL_TABLES.to_populate():
             # check if there are source files for all tables to be created
             if (file_glob := get_table_files_glob(table)) and not any(
                 dne_dir.glob(file_glob)

--- a/src/edne_correios_loader/table_set.py
+++ b/src/edne_correios_loader/table_set.py
@@ -1,6 +1,8 @@
 import enum
 
-from .tables import metadata
+from sqlalchemy import MetaData
+
+from .tables import metadata as default_metadata
 
 
 class TableSetEnum(enum.Enum):
@@ -12,15 +14,13 @@ class TableSetEnum(enum.Enum):
     CEP_TABLES = "cep-tables"
     ALL_TABLES = "all"
 
-    @property
-    def to_populate(self) -> list[str]:
+    def to_populate(self, metadata: MetaData = default_metadata) -> list[str]:
         if self.value == "all":
             return [t.name for t in metadata.sorted_tables]
 
-        return get_cep_tables()
+        return get_cep_tables(metadata)
 
-    @property
-    def to_drop(self) -> list[str]:
+    def to_drop(self, metadata: MetaData = default_metadata) -> list[str]:
         if self.value == "unified-cep-only":
             return [
                 t.name
@@ -31,7 +31,7 @@ class TableSetEnum(enum.Enum):
         return []
 
 
-def get_cep_tables() -> list[str]:
+def get_cep_tables(metadata: MetaData = default_metadata) -> list[str]:
     """
     Get the list of tables that are required for CEP search.
     """
@@ -48,14 +48,17 @@ def get_cep_tables() -> list[str]:
     return list(reversed(tables))
 
 
-def get_table_files_glob(table_name: str) -> str | None:
+def get_table_files_glob(
+    table_name: str, metadata: MetaData = default_metadata
+) -> str | None:
     """
     Get the file globs for each table.
-    Calculate from table name when not specified.
+    Calculate from original table name when not specified.
     """
     table = metadata.tables[table_name]
 
     if table.info.get("unified_table", False):
         return None
 
-    return table.info.get("file_glob", f"{table.name.upper()}.TXT")
+    original_name = table.info.get("original_name", table.name)
+    return table.info.get("file_glob", f"{original_name.upper()}.TXT")

--- a/src/edne_correios_loader/tables.py
+++ b/src/edne_correios_loader/tables.py
@@ -141,9 +141,7 @@ def build_metadata(table_names: TableNameResolver | None = None) -> MetaData:
             comment="CEP inicial da UF",
             nullable=False,
         ),
-        Column(
-            "ufe_cep_fim", String(8), comment="CEP final da UF", nullable=False
-        ),
+        Column("ufe_cep_fim", String(8), comment="CEP final da UF", nullable=False),
         info=info("log_faixa_uf"),
     )
 
@@ -176,9 +174,7 @@ def build_metadata(table_names: TableNameResolver | None = None) -> MetaData:
             comment="Sigla da UF",
             nullable=False,
         ),
-        Column(
-            "loc_no", String(72), comment="Nome da localidade", nullable=False
-        ),
+        Column("loc_no", String(72), comment="Nome da localidade", nullable=False),
         Column("cep", String(8), index=True, comment="CEP da localidade"),
         Column(
             "loc_in_sit",
@@ -253,9 +249,7 @@ def build_metadata(table_names: TableNameResolver | None = None) -> MetaData:
             primary_key=True,
             comment="CEP inicial da localidade",
         ),
-        Column(
-            "loc_cep_fim", String(8), comment="CEP final da localidade"
-        ),
+        Column("loc_cep_fim", String(8), comment="CEP final da localidade"),
         Column(
             "loc_tipo_faixa",
             Enum(
@@ -274,9 +268,7 @@ def build_metadata(table_names: TableNameResolver | None = None) -> MetaData:
     log_bairro = Table(
         n("log_bairro"),
         metadata,
-        Column(
-            "bai_nu", Integer, primary_key=True, comment="Chave do bairro"
-        ),
+        Column("bai_nu", Integer, primary_key=True, comment="Chave do bairro"),
         Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
         Column(
             "loc_nu",
@@ -285,9 +277,7 @@ def build_metadata(table_names: TableNameResolver | None = None) -> MetaData:
             comment="Chave da localidade",
             nullable=False,
         ),
-        Column(
-            "bai_no", String(72), comment="Nome do bairro", nullable=False
-        ),
+        Column("bai_no", String(72), comment="Nome do bairro", nullable=False),
         Column(
             "bai_no_abrev",
             String(36),
@@ -365,9 +355,7 @@ def build_metadata(table_names: TableNameResolver | None = None) -> MetaData:
             comment="Chave da localidade",
             nullable=False,
         ),
-        Column(
-            "cpc_no", String(72), comment="Nome da CPC", nullable=False
-        ),
+        Column("cpc_no", String(72), comment="Nome da CPC", nullable=False),
         Column(
             "cpc_endereco",
             String(100),
@@ -701,9 +689,7 @@ def build_metadata(table_names: TableNameResolver | None = None) -> MetaData:
     Table(
         n("ect_pais"),
         metadata,
-        Column(
-            "pai_sg", String(2), primary_key=True, comment="Sigla do país"
-        ),
+        Column("pai_sg", String(2), primary_key=True, comment="Sigla do país"),
         Column(
             "pai_sg_alternativa",
             String(3),
@@ -714,12 +700,8 @@ def build_metadata(table_names: TableNameResolver | None = None) -> MetaData:
             String(72),
             comment="Nome do país em português",
         ),
-        Column(
-            "pai_no_ingles", String(72), comment="Nome do país em inglês"
-        ),
-        Column(
-            "pai_no_frances", String(72), comment="Nome do país em francês"
-        ),
+        Column("pai_no_ingles", String(72), comment="Nome do país em inglês"),
+        Column("pai_no_frances", String(72), comment="Nome do país em francês"),
         Column(
             "pai_abreviatura",
             String(36),

--- a/src/edne_correios_loader/tables.py
+++ b/src/edne_correios_loader/tables.py
@@ -1,4 +1,5 @@
 import enum
+from collections.abc import Callable
 
 from sqlalchemy import (
     Column,
@@ -10,31 +11,45 @@ from sqlalchemy import (
     Table,
 )
 
-metadata = MetaData()
+"""
+Type for customizing table names.
 
+Can be a callable that transforms original names, or a dict mapping
+original names to custom names (unmapped names keep their defaults).
+"""
+TableNameResolver = Callable[[str], str] | dict[str, str]
 
 """
-Faixa de CEP de UF
+List of all default table names created by build_metadata().
 """
-log_faixa_uf = Table(
+DEFAULT_TABLE_NAMES = [
     "log_faixa_uf",
-    metadata,
-    Column(
-        "ufe_sg",
-        String(2),
-        primary_key=True,
-        comment="Sigla da UF",
-        nullable=False,
-    ),
-    Column(
-        "ufe_cep_ini",
-        String(8),
-        primary_key=True,
-        comment="CEP inicial da UF",
-        nullable=False,
-    ),
-    Column("ufe_cep_fim", String(8), comment="CEP final da UF", nullable=False),
-)
+    "log_localidade",
+    "log_var_loc",
+    "log_faixa_localidade",
+    "log_bairro",
+    "log_var_bai",
+    "log_faixa_bairro",
+    "log_cpc",
+    "log_faixa_cpc",
+    "log_logradouro",
+    "log_var_log",
+    "log_num_sec",
+    "log_grande_usuario",
+    "log_unid_oper",
+    "log_faixa_uop",
+    "ect_pais",
+    "cep_unificado",
+]
+
+
+def make_table_name_fn(resolver: TableNameResolver | None) -> Callable[[str], str]:
+    if resolver is None:
+        return lambda name: name
+    if isinstance(resolver, dict):
+        mapping = resolver
+        return lambda name: mapping.get(name, name)
+    return resolver
 
 
 class SituacaoLocalidadeEnum(enum.Enum):
@@ -69,86 +84,6 @@ class TipoLocalidadeEnum(enum.Enum):
     POVOADO = "P"
 
 
-"""
-Localidade
-
-O arquivo LOG_LOCALIDADE contempla os municípios, distritos e povoados do Brasil.
-
-Os CEPs presentes neste arquivo valem para todos os logradouros da cidade, não
-necessitando consulta nos demais arquivos.
-
-As localidades em fase de codificação(LOC_IN_SIT=3) estão em período de transição,
-sendo aceito o CEP Geral ou os CEPs de Logradouros para endereçamento.
-"""
-log_localidade = Table(
-    "log_localidade",
-    metadata,
-    Column(
-        "loc_nu",
-        Integer,
-        primary_key=True,
-        unique=True,
-        comment="Chave da localidade",
-        nullable=False,
-    ),
-    Column(
-        "ufe_sg",
-        String(2),
-        primary_key=True,
-        comment="Sigla da UF",
-        nullable=False,
-    ),
-    Column("loc_no", String(72), comment="Nome da localidade", nullable=False),
-    # CEP da localidade(para localidade não codificada, ou seja, loc_in_sit = 0)
-    Column("cep", String(8), index=True, comment="CEP da localidade"),
-    Column(
-        "loc_in_sit",
-        Enum(
-            SituacaoLocalidadeEnum,
-            values_callable=lambda x: [e.value for e in x],
-        ),
-        comment="Situação da localidade",
-        nullable=False,
-    ),
-    Column(
-        "loc_in_tipo_loc",
-        Enum(TipoLocalidadeEnum, values_callable=lambda x: [e.value for e in x]),
-        comment="Tipo de localidade",
-        nullable=False,
-    ),
-    Column(
-        "loc_nu_sub",
-        ForeignKey("log_localidade.loc_nu", ondelete="NO ACTION"),
-        index=True,
-        comment="Chave da localidade de subordinação",
-    ),
-    Column("loc_no_abrev", String(36), comment="Abreviatura do nome da localidade"),
-    Column("mun_nu", Integer, comment="Código do município IBGE"),
-)
-
-
-"""
-Outras denominações da Localidade (denominação popular, denominação anterior)
-"""
-log_var_loc = Table(
-    "log_var_loc",
-    metadata,
-    Column(
-        "loc_nu",
-        ForeignKey(log_localidade.c.loc_nu),
-        primary_key=True,
-        comment="Chave da localidade",
-    ),
-    Column(
-        "val_nu",
-        Integer,
-        primary_key=True,
-        comment="Ordem da denominação",
-    ),
-    Column("val_tx", String(72), comment="Denominação", nullable=False),
-)
-
-
 class TipoFaixaCepEnum(enum.Enum):
     """
     Tipo de faixa de CEP
@@ -159,227 +94,6 @@ class TipoFaixaCepEnum(enum.Enum):
 
     TOTAL_MUNICIPIO = "T"
     EXCLUSIVA_SEDE_URBANA = "C"
-
-
-"""
-Faixa de CEP das Localidades codificadas
-
-Este arquivo contém dados relativos às faixas de CEP das localidades classificadas na
-categoria político-administrativa de município codificadas com CEP único ou codificadas
-por logradouros.
-"""
-log_faixa_localidade = Table(
-    "log_faixa_localidade",
-    metadata,
-    Column(
-        "loc_nu",
-        ForeignKey(log_localidade.c.loc_nu),
-        primary_key=True,
-        comment="Chave da localidade",
-    ),
-    Column(
-        "loc_cep_ini",
-        String(8),
-        primary_key=True,
-        comment="CEP inicial da localidade",
-    ),
-    Column("loc_cep_fim", String(8), comment="CEP final da localidade"),
-    Column(
-        "loc_tipo_faixa",
-        Enum(TipoFaixaCepEnum, values_callable=lambda x: [e.value for e in x]),
-        primary_key=True,
-        comment="Tipo de faixa de CEP",
-    ),
-)
-
-"""
-Bairro
-"""
-log_bairro = Table(
-    "log_bairro",
-    metadata,
-    Column("bai_nu", Integer, primary_key=True, comment="Chave do bairro"),
-    Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
-    Column(
-        "loc_nu",
-        ForeignKey(log_localidade.c.loc_nu),
-        index=True,
-        comment="Chave da localidade",
-        nullable=False,
-    ),
-    Column("bai_no", String(72), comment="Nome do bairro", nullable=False),
-    Column(
-        "bai_no_abrev",
-        String(36),
-        comment="Abreviatura do nome do bairro",
-    ),
-)
-
-"""
-Outras denominações do Bairro Localidade (denominação popular, denominação anterior)
-"""
-log_var_bai = Table(
-    "log_var_bai",
-    metadata,
-    Column(
-        "bai_nu",
-        ForeignKey(log_bairro.c.bai_nu),
-        primary_key=True,
-        comment="Chave do bairro",
-    ),
-    Column("vdb_nu", Integer, primary_key=True, comment="Ordem da denominação"),
-    Column("vdb_tx", String(72), comment="Denominação", nullable=False),
-)
-
-
-"""
-Faixa de CEP de Bairro
-"""
-log_faixa_bairro = Table(
-    "log_faixa_bairro",
-    metadata,
-    Column(
-        "bai_nu",
-        ForeignKey(log_bairro.c.bai_nu),
-        primary_key=True,
-        comment="Chave do bairro",
-    ),
-    Column(
-        "fcb_cep_ini",
-        String(8),
-        primary_key=True,
-        comment="CEP inicial do bairro",
-    ),
-    Column("fcb_cep_fim", String(8), comment="CEP final do bairro", nullable=False),
-)
-
-
-"""
-Caixa Postal Comunitária (CPC)
-
-São áreas rurais e/ou urbanas periféricas não atendidas pela distribuição domiciliária.
-"""
-log_cpc = Table(
-    "log_cpc",
-    metadata,
-    Column(
-        "cpc_nu",
-        Integer,
-        primary_key=True,
-        comment="Chave da caixa postal comunitária",
-    ),
-    Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
-    Column(
-        "loc_nu",
-        ForeignKey(log_localidade.c.loc_nu),
-        index=True,
-        comment="Chave da localidade",
-        nullable=False,
-    ),
-    Column("cpc_no", String(72), comment="Nome da CPC", nullable=False),
-    Column("cpc_endereco", String(100), comment="Endereço da CPC", nullable=False),
-    Column("cep", String(8), index=True, comment="CEP da CPC", nullable=False),
-)
-
-"""
-Faixa de Caixa Postal Comunitária
-"""
-log_faixa_cpc = Table(
-    "log_faixa_cpc",
-    metadata,
-    Column(
-        "cpc_nu",
-        ForeignKey(log_cpc.c.cpc_nu),
-        primary_key=True,
-        comment="Chave da caixa postal comunitária",
-    ),
-    Column(
-        "cpc_inicial",
-        String(6),
-        comment="Número inicial da caixa postal comunitária",
-        primary_key=True,
-    ),
-    Column(
-        "cpc_final",
-        String(6),
-        comment="Número final da caixa postal comunitária",
-        primary_key=True,
-    ),
-)
-
-
-"""
-Logradouro
-
-Este arquivo contém os registros das localidades codificadas por logradouro
-(LOC_IN_SIT=1) e de localidades em fase de codificação (LOC_IN_SIT=3).
-
-Para encontrar o bairro do logradouro, utilize o campo BAI_NU_INI
-(relacionamento com LOG_BAIRRO, campo BAI_NU)
-"""
-log_logradouro = Table(
-    "log_logradouro",
-    metadata,
-    Column("log_nu", Integer, primary_key=True, comment="Chave do logradouro"),
-    Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
-    Column(
-        "loc_nu",
-        ForeignKey(log_localidade.c.loc_nu),
-        index=True,
-        comment="Chave da localidade",
-        nullable=False,
-    ),
-    Column(
-        "bai_nu_ini",
-        ForeignKey(log_bairro.c.bai_nu),
-        index=True,
-        comment="Chave do bairro inicial do logradouro",
-        nullable=False,
-    ),
-    Column(
-        "bai_nu_fim",
-        ForeignKey(log_bairro.c.bai_nu),
-        index=True,
-        comment="Chave do bairro final do logradouro",
-        nullable=True,
-    ),
-    Column("log_no", String(100), comment="Nome do logradouro", nullable=False),
-    Column("log_complemento", String(100), comment="Complemento"),
-    Column(
-        "cep",
-        String(8),
-        index=True,
-        comment="CEP do logradouro",
-        nullable=False,
-    ),
-    Column("tlo_tx", String(36), comment="Tipo de logradouro", nullable=False),
-    Column(
-        "log_sta_tlo",
-        String(1),
-        index=True,
-        comment="Indicador de utilização do tipo de logradouro (S/N)",
-    ),
-    Column("log_no_abrev", String(36), comment="Abreviatura do nome do logradouro"),
-    info={"file_glob": "LOG_LOGRADOURO_*.TXT"},
-)
-
-
-"""
-Outras denominações do Logradouro (denominação popular, denominação anterior)
-"""
-log_var_log = Table(
-    "log_var_log",
-    metadata,
-    Column(
-        "log_nu",
-        ForeignKey(log_logradouro.c.log_nu),
-        primary_key=True,
-        comment="Chave do logradouro",
-    ),
-    Column("vlo_nu", Integer, primary_key=True, comment="Ordem da denominação"),
-    Column("tlo_tx", String(36), comment="Tipo de logradouro da variação"),
-    Column("vlo_tx", String(150), comment="Nome da variação do logradouro"),
-)
 
 
 class SeccionamentoLadoEnum(enum.Enum):
@@ -394,216 +108,663 @@ class SeccionamentoLadoEnum(enum.Enum):
     ESQUERDO = "E"
 
 
-"""
-Faixa numérica do seccionamento
-"""
-log_num_sec = Table(
-    "log_num_sec",
-    metadata,
-    Column(
-        "log_nu",
-        ForeignKey(log_logradouro.c.log_nu),
-        primary_key=True,
-        comment="Chave do logradouro",
-    ),
-    Column("sec_nu_ini", String(10), comment="Número inicial do seccionamento"),
-    Column("sec_nu_fim", String(10), comment="Número final do seccionamento"),
-    Column(
-        "sec_in_lado",
-        Enum(
-            SeccionamentoLadoEnum,
-            values_callable=lambda x: [e.value for e in x],
+def build_metadata(table_names: TableNameResolver | None = None) -> MetaData:
+    """
+    Build a SQLAlchemy MetaData with all DNE table definitions.
+
+    Optionally accepts a TableNameResolver to customize table names.
+    When not provided, tables use their default names.
+    """
+    n = make_table_name_fn(table_names)
+    metadata = MetaData()
+
+    def info(original_name, **extra):
+        return {"original_name": original_name, **extra}
+
+    """
+    Faixa de CEP de UF
+    """
+    Table(
+        n("log_faixa_uf"),
+        metadata,
+        Column(
+            "ufe_sg",
+            String(2),
+            primary_key=True,
+            comment="Sigla da UF",
+            nullable=False,
         ),
-        comment="Indica a paridade/lado do seccionamento",
-    ),
-)
+        Column(
+            "ufe_cep_ini",
+            String(8),
+            primary_key=True,
+            comment="CEP inicial da UF",
+            nullable=False,
+        ),
+        Column(
+            "ufe_cep_fim", String(8), comment="CEP final da UF", nullable=False
+        ),
+        info=info("log_faixa_uf"),
+    )
+
+    """
+    Localidade
+
+    O arquivo LOG_LOCALIDADE contempla os municípios, distritos e povoados do Brasil.
+
+    Os CEPs presentes neste arquivo valem para todos os logradouros da cidade, não
+    necessitando consulta nos demais arquivos.
+
+    As localidades em fase de codificação(LOC_IN_SIT=3) estão em período de transição,
+    sendo aceito o CEP Geral ou os CEPs de Logradouros para endereçamento.
+    """
+    log_localidade = Table(
+        n("log_localidade"),
+        metadata,
+        Column(
+            "loc_nu",
+            Integer,
+            primary_key=True,
+            unique=True,
+            comment="Chave da localidade",
+            nullable=False,
+        ),
+        Column(
+            "ufe_sg",
+            String(2),
+            primary_key=True,
+            comment="Sigla da UF",
+            nullable=False,
+        ),
+        Column(
+            "loc_no", String(72), comment="Nome da localidade", nullable=False
+        ),
+        Column("cep", String(8), index=True, comment="CEP da localidade"),
+        Column(
+            "loc_in_sit",
+            Enum(
+                SituacaoLocalidadeEnum,
+                values_callable=lambda x: [e.value for e in x],
+            ),
+            comment="Situação da localidade",
+            nullable=False,
+        ),
+        Column(
+            "loc_in_tipo_loc",
+            Enum(
+                TipoLocalidadeEnum,
+                values_callable=lambda x: [e.value for e in x],
+            ),
+            comment="Tipo de localidade",
+            nullable=False,
+        ),
+        Column(
+            "loc_nu_sub",
+            ForeignKey(n("log_localidade") + ".loc_nu", ondelete="NO ACTION"),
+            index=True,
+            comment="Chave da localidade de subordinação",
+        ),
+        Column(
+            "loc_no_abrev",
+            String(36),
+            comment="Abreviatura do nome da localidade",
+        ),
+        Column("mun_nu", Integer, comment="Código do município IBGE"),
+        info=info("log_localidade"),
+    )
+
+    """
+    Outras denominações da Localidade (denominação popular, denominação anterior)
+    """
+    Table(
+        n("log_var_loc"),
+        metadata,
+        Column(
+            "loc_nu",
+            ForeignKey(log_localidade.c.loc_nu),
+            primary_key=True,
+            comment="Chave da localidade",
+        ),
+        Column(
+            "val_nu",
+            Integer,
+            primary_key=True,
+            comment="Ordem da denominação",
+        ),
+        Column("val_tx", String(72), comment="Denominação", nullable=False),
+        info=info("log_var_loc"),
+    )
+
+    """
+    Faixa de CEP das Localidades codificadas
+    """
+    Table(
+        n("log_faixa_localidade"),
+        metadata,
+        Column(
+            "loc_nu",
+            ForeignKey(log_localidade.c.loc_nu),
+            primary_key=True,
+            comment="Chave da localidade",
+        ),
+        Column(
+            "loc_cep_ini",
+            String(8),
+            primary_key=True,
+            comment="CEP inicial da localidade",
+        ),
+        Column(
+            "loc_cep_fim", String(8), comment="CEP final da localidade"
+        ),
+        Column(
+            "loc_tipo_faixa",
+            Enum(
+                TipoFaixaCepEnum,
+                values_callable=lambda x: [e.value for e in x],
+            ),
+            primary_key=True,
+            comment="Tipo de faixa de CEP",
+        ),
+        info=info("log_faixa_localidade"),
+    )
+
+    """
+    Bairro
+    """
+    log_bairro = Table(
+        n("log_bairro"),
+        metadata,
+        Column(
+            "bai_nu", Integer, primary_key=True, comment="Chave do bairro"
+        ),
+        Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
+        Column(
+            "loc_nu",
+            ForeignKey(log_localidade.c.loc_nu),
+            index=True,
+            comment="Chave da localidade",
+            nullable=False,
+        ),
+        Column(
+            "bai_no", String(72), comment="Nome do bairro", nullable=False
+        ),
+        Column(
+            "bai_no_abrev",
+            String(36),
+            comment="Abreviatura do nome do bairro",
+        ),
+        info=info("log_bairro"),
+    )
+
+    """
+    Outras denominações do Bairro
+    """
+    Table(
+        n("log_var_bai"),
+        metadata,
+        Column(
+            "bai_nu",
+            ForeignKey(log_bairro.c.bai_nu),
+            primary_key=True,
+            comment="Chave do bairro",
+        ),
+        Column(
+            "vdb_nu",
+            Integer,
+            primary_key=True,
+            comment="Ordem da denominação",
+        ),
+        Column("vdb_tx", String(72), comment="Denominação", nullable=False),
+        info=info("log_var_bai"),
+    )
+
+    """
+    Faixa de CEP de Bairro
+    """
+    Table(
+        n("log_faixa_bairro"),
+        metadata,
+        Column(
+            "bai_nu",
+            ForeignKey(log_bairro.c.bai_nu),
+            primary_key=True,
+            comment="Chave do bairro",
+        ),
+        Column(
+            "fcb_cep_ini",
+            String(8),
+            primary_key=True,
+            comment="CEP inicial do bairro",
+        ),
+        Column(
+            "fcb_cep_fim",
+            String(8),
+            comment="CEP final do bairro",
+            nullable=False,
+        ),
+        info=info("log_faixa_bairro"),
+    )
+
+    """
+    Caixa Postal Comunitária (CPC)
+    """
+    log_cpc = Table(
+        n("log_cpc"),
+        metadata,
+        Column(
+            "cpc_nu",
+            Integer,
+            primary_key=True,
+            comment="Chave da caixa postal comunitária",
+        ),
+        Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
+        Column(
+            "loc_nu",
+            ForeignKey(log_localidade.c.loc_nu),
+            index=True,
+            comment="Chave da localidade",
+            nullable=False,
+        ),
+        Column(
+            "cpc_no", String(72), comment="Nome da CPC", nullable=False
+        ),
+        Column(
+            "cpc_endereco",
+            String(100),
+            comment="Endereço da CPC",
+            nullable=False,
+        ),
+        Column(
+            "cep",
+            String(8),
+            index=True,
+            comment="CEP da CPC",
+            nullable=False,
+        ),
+        info=info("log_cpc"),
+    )
+
+    """
+    Faixa de Caixa Postal Comunitária
+    """
+    Table(
+        n("log_faixa_cpc"),
+        metadata,
+        Column(
+            "cpc_nu",
+            ForeignKey(log_cpc.c.cpc_nu),
+            primary_key=True,
+            comment="Chave da caixa postal comunitária",
+        ),
+        Column(
+            "cpc_inicial",
+            String(6),
+            comment="Número inicial da caixa postal comunitária",
+            primary_key=True,
+        ),
+        Column(
+            "cpc_final",
+            String(6),
+            comment="Número final da caixa postal comunitária",
+            primary_key=True,
+        ),
+        info=info("log_faixa_cpc"),
+    )
+
+    """
+    Logradouro
+    """
+    log_logradouro = Table(
+        n("log_logradouro"),
+        metadata,
+        Column(
+            "log_nu",
+            Integer,
+            primary_key=True,
+            comment="Chave do logradouro",
+        ),
+        Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
+        Column(
+            "loc_nu",
+            ForeignKey(log_localidade.c.loc_nu),
+            index=True,
+            comment="Chave da localidade",
+            nullable=False,
+        ),
+        Column(
+            "bai_nu_ini",
+            ForeignKey(log_bairro.c.bai_nu),
+            index=True,
+            comment="Chave do bairro inicial do logradouro",
+            nullable=False,
+        ),
+        Column(
+            "bai_nu_fim",
+            ForeignKey(log_bairro.c.bai_nu),
+            index=True,
+            comment="Chave do bairro final do logradouro",
+            nullable=True,
+        ),
+        Column(
+            "log_no",
+            String(100),
+            comment="Nome do logradouro",
+            nullable=False,
+        ),
+        Column("log_complemento", String(100), comment="Complemento"),
+        Column(
+            "cep",
+            String(8),
+            index=True,
+            comment="CEP do logradouro",
+            nullable=False,
+        ),
+        Column(
+            "tlo_tx",
+            String(36),
+            comment="Tipo de logradouro",
+            nullable=False,
+        ),
+        Column(
+            "log_sta_tlo",
+            String(1),
+            index=True,
+            comment="Indicador de utilização do tipo de logradouro (S/N)",
+        ),
+        Column(
+            "log_no_abrev",
+            String(36),
+            comment="Abreviatura do nome do logradouro",
+        ),
+        info=info("log_logradouro", file_glob="LOG_LOGRADOURO_*.TXT"),
+    )
+
+    """
+    Outras denominações do Logradouro
+    """
+    Table(
+        n("log_var_log"),
+        metadata,
+        Column(
+            "log_nu",
+            ForeignKey(log_logradouro.c.log_nu),
+            primary_key=True,
+            comment="Chave do logradouro",
+        ),
+        Column(
+            "vlo_nu",
+            Integer,
+            primary_key=True,
+            comment="Ordem da denominação",
+        ),
+        Column(
+            "tlo_tx",
+            String(36),
+            comment="Tipo de logradouro da variação",
+        ),
+        Column(
+            "vlo_tx",
+            String(150),
+            comment="Nome da variação do logradouro",
+        ),
+        info=info("log_var_log"),
+    )
+
+    """
+    Faixa numérica do seccionamento
+    """
+    Table(
+        n("log_num_sec"),
+        metadata,
+        Column(
+            "log_nu",
+            ForeignKey(log_logradouro.c.log_nu),
+            primary_key=True,
+            comment="Chave do logradouro",
+        ),
+        Column(
+            "sec_nu_ini",
+            String(10),
+            comment="Número inicial do seccionamento",
+        ),
+        Column(
+            "sec_nu_fim",
+            String(10),
+            comment="Número final do seccionamento",
+        ),
+        Column(
+            "sec_in_lado",
+            Enum(
+                SeccionamentoLadoEnum,
+                values_callable=lambda x: [e.value for e in x],
+            ),
+            comment="Indica a paridade/lado do seccionamento",
+        ),
+        info=info("log_num_sec"),
+    )
+
+    """
+    Grande usuário
+    """
+    Table(
+        n("log_grande_usuario"),
+        metadata,
+        Column(
+            "gru_nu",
+            Integer,
+            primary_key=True,
+            comment="Chave do grande usuário",
+        ),
+        Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
+        Column(
+            "loc_nu",
+            ForeignKey(log_localidade.c.loc_nu),
+            index=True,
+            comment="Chave da localidade",
+            nullable=False,
+        ),
+        Column(
+            "bai_nu",
+            ForeignKey(log_bairro.c.bai_nu),
+            index=True,
+            comment="Chave do bairro",
+            nullable=False,
+        ),
+        Column(
+            "log_nu",
+            ForeignKey(log_logradouro.c.log_nu),
+            index=True,
+            comment="Chave do logradouro",
+        ),
+        Column(
+            "gru_no",
+            String(72),
+            comment="Nome do grande usuário",
+            nullable=False,
+        ),
+        Column(
+            "gru_endereco",
+            String(100),
+            comment="Endereço do grande usuário",
+            nullable=False,
+        ),
+        Column(
+            "cep",
+            String(8),
+            index=True,
+            comment="CEP do grande usuário",
+            nullable=False,
+        ),
+        Column(
+            "gru_no_abrev",
+            String(36),
+            comment="Abreviatura do nome do grande usuário",
+        ),
+        info=info("log_grande_usuario"),
+    )
+
+    """
+    Unidade Operacional dos Correios.
+    """
+    log_unid_oper = Table(
+        n("log_unid_oper"),
+        metadata,
+        Column(
+            "uop_nu",
+            Integer,
+            primary_key=True,
+            comment="Chave da unidade operacional",
+        ),
+        Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
+        Column(
+            "loc_nu",
+            ForeignKey(log_localidade.c.loc_nu),
+            index=True,
+            comment="Chave da localidade",
+            nullable=False,
+        ),
+        Column(
+            "bai_nu",
+            ForeignKey(log_bairro.c.bai_nu),
+            index=True,
+            comment="Chave do bairro",
+            nullable=False,
+        ),
+        Column(
+            "log_nu",
+            ForeignKey(log_logradouro.c.log_nu),
+            index=True,
+            comment="Chave do logradouro",
+        ),
+        Column(
+            "uop_no",
+            String(100),
+            comment="Nome da unidade operacional",
+            nullable=False,
+        ),
+        Column(
+            "uop_endereco",
+            String(100),
+            comment="Endereço da unidade operacional",
+            nullable=False,
+        ),
+        Column(
+            "cep",
+            String(8),
+            index=True,
+            comment="CEP da unidade operacional",
+            nullable=False,
+        ),
+        Column(
+            "uop_in_cp",
+            String(1),
+            comment="Indicador de unidade operacional com caixa postal (S/N)",
+        ),
+        Column(
+            "uop_no_abrev",
+            String(36),
+            comment="Abreviatura do nome da unidade operacional",
+        ),
+        info=info("log_unid_oper"),
+    )
+
+    """
+    Faixa de Caixa Postal - UOP
+    """
+    Table(
+        n("log_faixa_uop"),
+        metadata,
+        Column(
+            "upo_nu",
+            ForeignKey(log_unid_oper.c.uop_nu),
+            primary_key=True,
+            comment="Chave da unidade operacional",
+        ),
+        Column(
+            "fnc_inicial",
+            Integer,
+            primary_key=True,
+            comment="Número inicial da caixa postal",
+        ),
+        Column(
+            "fnc_final",
+            Integer,
+            comment="Número final da caixa postal",
+            nullable=False,
+        ),
+        info=info("log_faixa_uop"),
+    )
+
+    """
+    Relação dos Nomes dos Países
+    """
+    Table(
+        n("ect_pais"),
+        metadata,
+        Column(
+            "pai_sg", String(2), primary_key=True, comment="Sigla do país"
+        ),
+        Column(
+            "pai_sg_alternativa",
+            String(3),
+            comment="Sigla alternativa do país",
+        ),
+        Column(
+            "pai_no_portugues",
+            String(72),
+            comment="Nome do país em português",
+        ),
+        Column(
+            "pai_no_ingles", String(72), comment="Nome do país em inglês"
+        ),
+        Column(
+            "pai_no_frances", String(72), comment="Nome do país em francês"
+        ),
+        Column(
+            "pai_abreviatura",
+            String(36),
+            comment="Abreviatura do nome do país",
+        ),
+        info=info("ect_pais"),
+    )
+
+    """
+    Tabela unificada de CEP
+    """
+    Table(
+        n("cep_unificado"),
+        metadata,
+        Column("cep", String(8), primary_key=True),
+        Column("logradouro", String(100)),
+        Column("complemento", String(100)),
+        Column("bairro", String(72)),
+        Column("municipio", String(72), nullable=False),
+        Column("municipio_cod_ibge", Integer, nullable=False),
+        Column("uf", String(2), nullable=False),
+        Column("nome", String(100)),
+        info=info("cep_unificado", unified_table=True),
+    )
+
+    metadata.info["original_name_map"] = {
+        t.info["original_name"]: t.name for t in metadata.sorted_tables
+    }
+
+    return metadata
 
 
-"""
-Grande usuário
+def get_table(metadata: MetaData, original_name: str):
+    """
+    Look up a table by its original (default) name, even if it was renamed.
+    """
+    original_name_map = metadata.info.get("original_name_map", {})
+    table_name = original_name_map.get(original_name)
 
-São clientes com grande volume postal (empresas, universidades, bancos,
-órgãos públicos, etc).
+    if table_name is None:
+        msg = f"Table with original name '{original_name}' not found"
+        raise KeyError(msg)
 
-O campo LOG_NU está sem conteúdo para as localidades não codificadas(LOC_IN_SIT=0),
-devendo ser utilizado o campo GRU_ENDEREÇO para  endereçamento.
-"""
-log_grande_usuario = Table(
-    "log_grande_usuario",
-    metadata,
-    Column("gru_nu", Integer, primary_key=True, comment="Chave do grande usuário"),
-    Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
-    Column(
-        "loc_nu",
-        ForeignKey(log_localidade.c.loc_nu),
-        index=True,
-        comment="Chave da localidade",
-        nullable=False,
-    ),
-    Column(
-        "bai_nu",
-        ForeignKey(log_bairro.c.bai_nu),
-        index=True,
-        comment="Chave do bairro",
-        nullable=False,
-    ),
-    Column(
-        "log_nu",
-        ForeignKey(log_logradouro.c.log_nu),
-        index=True,
-        comment="Chave do logradouro",
-    ),
-    Column("gru_no", String(72), comment="Nome do grande usuário", nullable=False),
-    Column(
-        "gru_endereco",
-        String(100),
-        comment="Endereço do grande usuário",
-        nullable=False,
-    ),
-    Column(
-        "cep",
-        String(8),
-        index=True,
-        comment="CEP do grande usuário",
-        nullable=False,
-    ),
-    Column(
-        "gru_no_abrev",
-        String(36),
-        comment="Abreviatura do nome do grande usuário",
-    ),
-)
-
-"""
-Unidade Operacional dos Correios.
-
-São agências próprias ou terceirizadas, centros de distribuição, etc.
-O campo LOG_NU está sem conteúdo para as localidades não codificadas(LOC_IN_SIT=0),
-devendo ser utilizado o campo UOP_ENDEREÇO para endereçamento.
-"""
-log_unid_oper = Table(
-    "log_unid_oper",
-    metadata,
-    Column(
-        "uop_nu",
-        Integer,
-        primary_key=True,
-        comment="Chave da unidade operacional",
-    ),
-    Column("ufe_sg", String(2), comment="Sigla da UF", nullable=False),
-    Column(
-        "loc_nu",
-        ForeignKey(log_localidade.c.loc_nu),
-        index=True,
-        comment="Chave da localidade",
-        nullable=False,
-    ),
-    Column(
-        "bai_nu",
-        ForeignKey(log_bairro.c.bai_nu),
-        index=True,
-        comment="Chave do bairro",
-        nullable=False,
-    ),
-    Column(
-        "log_nu",
-        ForeignKey(log_logradouro.c.log_nu),
-        index=True,
-        comment="Chave do logradouro",
-    ),
-    Column(
-        "uop_no",
-        String(100),
-        comment="Nome da unidade operacional",
-        nullable=False,
-    ),
-    Column(
-        "uop_endereco",
-        String(100),
-        comment="Endereço da unidade operacional",
-        nullable=False,
-    ),
-    Column(
-        "cep",
-        String(8),
-        index=True,
-        comment="CEP da unidade operacional",
-        nullable=False,
-    ),
-    Column(
-        "uop_in_cp",
-        String(1),
-        comment="Indicador de unidade operacional com caixa postal (S/N)",
-    ),
-    Column(
-        "uop_no_abrev",
-        String(36),
-        comment="Abreviatura do nome da unidade operacional",
-    ),
-)
+    return metadata.tables[table_name]
 
 
-"""
-Faixa de Caixa Postal - UOP
-"""
-log_faixa_uop = Table(
-    "log_faixa_uop",
-    metadata,
-    Column(
-        "upo_nu",
-        ForeignKey(log_unid_oper.c.uop_nu),
-        primary_key=True,
-        comment="Chave da unidade operacional",
-    ),
-    Column(
-        "fnc_inicial",
-        Integer,
-        primary_key=True,
-        comment="Número inicial da caixa postal",
-    ),
-    Column(
-        "fnc_final",
-        Integer,
-        comment="Número final da caixa postal",
-        nullable=False,
-    ),
-)
-
-
-"""
-Relação dos Nomes dos Países, suas siglas e grafias em inglês e francês
-"""
-ect_pais = Table(
-    "ect_pais",
-    metadata,
-    Column("pai_sg", String(2), primary_key=True, comment="Sigla do país"),
-    Column("pai_sg_alternativa", String(3), comment="Sigla alternativa do país"),
-    Column("pai_no_portugues", String(72), comment="Nome do país em português"),
-    Column("pai_no_ingles", String(72), comment="Nome do país em inglês"),
-    Column("pai_no_frances", String(72), comment="Nome do país em francês"),
-    Column("pai_abreviatura", String(36), comment="Abreviatura do nome do país"),
-)
-
-
-"""
-Tabela unificada de CEP
-
-Não inclusa no DNE, é populada com dados das outras tabelas depois que a importação
-é concluída.
-"""
-cep_unificado = Table(
-    "cep_unificado",
-    metadata,
-    Column("cep", String(8), primary_key=True),
-    Column("logradouro", String(100)),
-    Column("complemento", String(100)),
-    Column("bairro", String(72)),
-    Column("municipio", String(72), nullable=False),
-    Column("municipio_cod_ibge", Integer, nullable=False),
-    Column("uf", String(2), nullable=False),
-    # In some special cases, a CEP is assigned to a single address and may have a name.
-    # That happens for government agencies, large clients, some condos,
-    # Correios' own buildings, etc.
-    Column("nome", String(100)),
-    info={"unified_table": True},
-)
+# Default metadata for backward compatibility
+metadata = build_metadata()

--- a/src/edne_correios_loader/unified_table.py
+++ b/src/edne_correios_loader/unified_table.py
@@ -2,21 +2,15 @@ import logging
 from collections.abc import Iterable, Iterator
 
 import sqlalchemy as sa
+from sqlalchemy import MetaData
 
-from .tables import (
-    cep_unificado,
-    log_bairro,
-    log_cpc,
-    log_grande_usuario,
-    log_localidade,
-    log_logradouro,
-    log_unid_oper,
-)
+from .tables import get_table
+from .tables import metadata as default_metadata
 
 logger = logging.getLogger(__name__)
 
 
-def cep_unificado_insert_from(rows: "sa.Select"):
+def cep_unificado_insert_from(cep_unificado, rows: "sa.Select"):
     return cep_unificado.insert().from_select(rows.selected_columns, rows.subquery())
 
 
@@ -34,7 +28,7 @@ def normalize_logradouro(rows: "sa.CursorResult") -> Iterator[dict]:
 
 
 def cep_unificado_insert_in_batches(
-    conn: sa.Connection, rows: Iterable[dict], batch_size: int = 500
+    conn: sa.Connection, cep_unificado, rows: Iterable[dict], batch_size: int = 500
 ):
     """
     Insert rows in the unified table in batches
@@ -54,7 +48,11 @@ def cep_unificado_insert_in_batches(
         conn.execute(cep_unificado.insert().values(batch))
 
 
-def select_logradouros_ceps() -> "sa.Select":
+def select_logradouros_ceps(metadata) -> "sa.Select":
+    log_logradouro = get_table(metadata, "log_logradouro")
+    log_bairro = get_table(metadata, "log_bairro")
+    log_localidade = get_table(metadata, "log_localidade")
+
     return sa.select(
         log_logradouro.c.cep.label("cep"),
         sa.case(
@@ -75,7 +73,9 @@ def select_logradouros_ceps() -> "sa.Select":
     )
 
 
-def select_localidades_ceps() -> "sa.Select":
+def select_localidades_ceps(metadata) -> "sa.Select":
+    log_localidade = get_table(metadata, "log_localidade")
+
     return (
         sa.select(
             log_localidade.c.cep.label("cep"),
@@ -92,7 +92,8 @@ def select_localidades_ceps() -> "sa.Select":
     )
 
 
-def select_localidades_subordinadas_ceps() -> "sa.Select":
+def select_localidades_subordinadas_ceps(metadata) -> "sa.Select":
+    log_localidade = get_table(metadata, "log_localidade")
     localidade_subordinada = log_localidade.alias()
 
     return (
@@ -116,7 +117,9 @@ def select_localidades_subordinadas_ceps() -> "sa.Select":
     )
 
 
-def select_cpc_ceps() -> "sa.Select":
+def select_cpc_ceps(metadata) -> "sa.Select":
+    log_cpc = get_table(metadata, "log_cpc")
+    log_localidade = get_table(metadata, "log_localidade")
     localidade_subordinada = log_localidade.alias()
 
     return (
@@ -143,7 +146,10 @@ def select_cpc_ceps() -> "sa.Select":
     )
 
 
-def select_grandes_usuarios_ceps() -> "sa.Select":
+def select_grandes_usuarios_ceps(metadata) -> "sa.Select":
+    log_grande_usuario = get_table(metadata, "log_grande_usuario")
+    log_bairro = get_table(metadata, "log_bairro")
+    log_localidade = get_table(metadata, "log_localidade")
     localidade_subordinada = log_localidade.alias()
 
     return (
@@ -172,7 +178,10 @@ def select_grandes_usuarios_ceps() -> "sa.Select":
     )
 
 
-def select_unidades_operacionais_ceps() -> "sa.Select":
+def select_unidades_operacionais_ceps(metadata) -> "sa.Select":
+    log_unid_oper = get_table(metadata, "log_unid_oper")
+    log_bairro = get_table(metadata, "log_bairro")
+    log_localidade = get_table(metadata, "log_localidade")
     localidade_subordinada = log_localidade.alias()
 
     return (
@@ -207,14 +216,20 @@ def select_unidades_operacionais_ceps() -> "sa.Select":
     )
 
 
-def populate_unified_table(conn: sa.Connection, insert_batch_size: int = 500):
+def populate_unified_table(
+    conn: sa.Connection,
+    metadata: MetaData = default_metadata,
+    insert_batch_size: int = 500,
+):
     """
     Query unifying rows from all tables with CEP address information
     """
+    cep_unificado = get_table(metadata, "cep_unificado")
+
     insert_from_selects = [
-        (select_logradouros_ceps(), "logradouros"),
-        (select_localidades_ceps(), "localidades"),
-        (select_localidades_subordinadas_ceps(), "localidades subordinadas"),
+        (select_logradouros_ceps(metadata), "logradouros"),
+        (select_localidades_ceps(metadata), "localidades"),
+        (select_localidades_subordinadas_ceps(metadata), "localidades subordinadas"),
     ]
 
     for select_stmt, name in insert_from_selects:
@@ -223,7 +238,7 @@ def populate_unified_table(conn: sa.Connection, insert_batch_size: int = 500):
             name,
             extra={"indentation": 1},
         )
-        conn.execute(cep_unificado_insert_from(select_stmt))
+        conn.execute(cep_unificado_insert_from(cep_unificado, select_stmt))
 
         inserted = conn.execute(
             sa.select(sa.func.count()).select_from(select_stmt.subquery())
@@ -241,9 +256,9 @@ def populate_unified_table(conn: sa.Connection, insert_batch_size: int = 500):
     # they are normalized via python, so this can run for different DBMSs
 
     selects_with_normalization = [
-        (select_cpc_ceps(), "CPC"),
-        (select_grandes_usuarios_ceps(), "grandes usuários"),
-        (select_unidades_operacionais_ceps(), "unidades operacionais"),
+        (select_cpc_ceps(metadata), "CPC"),
+        (select_grandes_usuarios_ceps(metadata), "grandes usuários"),
+        (select_unidades_operacionais_ceps(metadata), "unidades operacionais"),
     ]
 
     for select_stmt, name in selects_with_normalization:
@@ -255,6 +270,7 @@ def populate_unified_table(conn: sa.Connection, insert_batch_size: int = 500):
 
         cep_unificado_insert_in_batches(
             conn,
+            cep_unificado,
             normalize_logradouro(conn.execute(select_stmt).yield_per(1000)),
             batch_size=insert_batch_size,
         )

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -21,7 +21,7 @@ class CreateTemporaryDneDirectory:
         shutil.rmtree(self.outerdir)
 
     def create_files(self):
-        for table in TableSetEnum.ALL_TABLES.to_populate:
+        for table in TableSetEnum.ALL_TABLES.to_populate():
             glob = get_table_files_glob(table)
 
             if glob is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,7 +73,9 @@ def test_cli_load_command_accepts_use_default_options(mocked_dne_loader):
     runner = CliRunner()
     result = runner.invoke(load, ["-db", db_url])
 
-    mocked_dne_loader.assert_called_once_with(db_url, dne_source=None)
+    mocked_dne_loader.assert_called_once_with(
+        db_url, dne_source=None, table_names=None
+    )
     mocked_dne_loader.return_value.load.assert_called_once_with(
         table_set=TableSetEnum.UNIFIED_CEP_ONLY
     )
@@ -109,8 +111,76 @@ def test_cli_load_command_use_provided_options(mocked_dne_loader):
     )
 
     assert result.exit_code == 0
-    mocked_dne_loader.assert_called_once_with(db_url, dne_source=dne_source)
+    mocked_dne_loader.assert_called_once_with(
+        db_url, dne_source=dne_source, table_names=None
+    )
     mocked_dne_loader.return_value.load.assert_called_once_with(table_set=table_set)
+
+
+# --- --table-name ---
+
+
+def test_cli_load_with_single_table_name(mocked_dne_loader):
+    runner = CliRunner()
+    result = runner.invoke(
+        load,
+        ["-db", "db-url", "--table-name", "cep_unificado=my_cep"],
+    )
+
+    assert result.exit_code == 0
+    mocked_dne_loader.assert_called_once_with(
+        "db-url",
+        dne_source=None,
+        table_names={"cep_unificado": "my_cep"},
+    )
+
+
+def test_cli_load_with_multiple_table_names(mocked_dne_loader):
+    runner = CliRunner()
+    result = runner.invoke(
+        load,
+        [
+            "-db", "db-url",
+            "--table-name", "cep_unificado=my_cep",
+            "--table-name", "log_localidade=my_loc",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mocked_dne_loader.assert_called_once_with(
+        "db-url",
+        dne_source=None,
+        table_names={"cep_unificado": "my_cep", "log_localidade": "my_loc"},
+    )
+
+
+def test_cli_load_table_name_rejects_invalid_format():
+    runner = CliRunner()
+
+    result = runner.invoke(load, ["-db", "db-url", "--table-name", "no_equals"])
+    assert result.exit_code == 2
+    assert "Expected format" in result.output
+
+    result = runner.invoke(load, ["-db", "db-url", "--table-name", "=value"])
+    assert result.exit_code == 2
+    assert "Expected format" in result.output
+
+    result = runner.invoke(load, ["-db", "db-url", "--table-name", "key="])
+    assert result.exit_code == 2
+    assert "Expected format" in result.output
+
+
+def test_cli_load_table_name_rejects_unknown_table():
+    runner = CliRunner()
+    result = runner.invoke(
+        load, ["-db", "db-url", "--table-name", "nonexistent=foo"]
+    )
+
+    assert result.exit_code == 2
+    assert "Unknown table name" in result.output
+
+
+# --- query-cep --cep-table-name ---
 
 
 def test_cli_query_cep_command_asks_for_required_arguments():
@@ -147,6 +217,30 @@ def test_cli_query_cep_uses_args_correctly(mocked_cep_querier):
     assert result.exit_code == 3
     assert result.stderr.strip() == "CEP not found"
     mocked_cep_querier.return_value.query.assert_called_once_with(cep)
+
+
+def test_cli_query_cep_uses_default_table_name(mocked_cep_querier):
+    runner = CliRunner()
+    runner.invoke(query_cep, ["-db", "db-url", "12345678"])
+
+    mocked_cep_querier.assert_called_once_with(
+        "db-url", cep_table_name=None
+    )
+
+
+def test_cli_query_cep_with_custom_table_name(mocked_cep_querier):
+    mocked_cep_querier.return_value.query.return_value = {"cep": "12345678"}
+
+    runner = CliRunner()
+    result = runner.invoke(
+        query_cep,
+        ["-db", "db-url", "--cep-table-name", "my_cep", "12345678"],
+    )
+
+    assert result.exit_code == 0
+    mocked_cep_querier.assert_called_once_with(
+        "db-url", cep_table_name="my_cep"
+    )
 
 
 def test_cli_query_cep_capture_and_display_errors(mocked_cep_querier):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,9 +73,7 @@ def test_cli_load_command_accepts_use_default_options(mocked_dne_loader):
     runner = CliRunner()
     result = runner.invoke(load, ["-db", db_url])
 
-    mocked_dne_loader.assert_called_once_with(
-        db_url, dne_source=None, table_names=None
-    )
+    mocked_dne_loader.assert_called_once_with(db_url, dne_source=None, table_names=None)
     mocked_dne_loader.return_value.load.assert_called_once_with(
         table_set=TableSetEnum.UNIFIED_CEP_ONLY
     )
@@ -140,9 +138,12 @@ def test_cli_load_with_multiple_table_names(mocked_dne_loader):
     result = runner.invoke(
         load,
         [
-            "-db", "db-url",
-            "--table-name", "cep_unificado=my_cep",
-            "--table-name", "log_localidade=my_loc",
+            "-db",
+            "db-url",
+            "--table-name",
+            "cep_unificado=my_cep",
+            "--table-name",
+            "log_localidade=my_loc",
         ],
     )
 
@@ -172,9 +173,7 @@ def test_cli_load_table_name_rejects_invalid_format():
 
 def test_cli_load_table_name_rejects_unknown_table():
     runner = CliRunner()
-    result = runner.invoke(
-        load, ["-db", "db-url", "--table-name", "nonexistent=foo"]
-    )
+    result = runner.invoke(load, ["-db", "db-url", "--table-name", "nonexistent=foo"])
 
     assert result.exit_code == 2
     assert "Unknown table name" in result.output
@@ -223,9 +222,7 @@ def test_cli_query_cep_uses_default_table_name(mocked_cep_querier):
     runner = CliRunner()
     runner.invoke(query_cep, ["-db", "db-url", "12345678"])
 
-    mocked_cep_querier.assert_called_once_with(
-        "db-url", cep_table_name=None
-    )
+    mocked_cep_querier.assert_called_once_with("db-url", cep_table_name=None)
 
 
 def test_cli_query_cep_with_custom_table_name(mocked_cep_querier):
@@ -238,9 +235,7 @@ def test_cli_query_cep_with_custom_table_name(mocked_cep_querier):
     )
 
     assert result.exit_code == 0
-    mocked_cep_querier.assert_called_once_with(
-        "db-url", cep_table_name="my_cep"
-    )
+    mocked_cep_querier.assert_called_once_with("db-url", cep_table_name="my_cep")
 
 
 def test_cli_query_cep_capture_and_display_errors(mocked_cep_querier):

--- a/tests/test_custom_table_names.py
+++ b/tests/test_custom_table_names.py
@@ -1,0 +1,292 @@
+from unittest.mock import sentinel
+
+import pytest
+import sqlalchemy as sa
+
+from edne_correios_loader import CepQuerier, DneLoader
+from edne_correios_loader.table_set import (
+    TableSetEnum,
+    get_cep_tables,
+    get_table_files_glob,
+)
+from edne_correios_loader.tables import (
+    DEFAULT_TABLE_NAMES,
+    build_metadata,
+    get_table,
+    make_table_name_fn,
+)
+
+# --- make_table_name_fn ---
+
+
+def test_make_table_name_fn_with_none_returns_identity():
+    fn = make_table_name_fn(None)
+    assert fn("log_localidade") == "log_localidade"
+
+
+def test_make_table_name_fn_with_dict_maps_known_keys():
+    fn = make_table_name_fn({"log_localidade": "my_loc"})
+    assert fn("log_localidade") == "my_loc"
+
+
+def test_make_table_name_fn_with_dict_falls_back_to_original():
+    fn = make_table_name_fn({"log_localidade": "my_loc"})
+    assert fn("log_bairro") == "log_bairro"
+
+
+def test_make_table_name_fn_with_callable():
+    fn = make_table_name_fn(lambda name: f"dne_{name}")
+    assert fn("log_localidade") == "dne_log_localidade"
+
+
+# --- build_metadata ---
+
+
+def test_build_metadata_default_uses_original_names():
+    metadata = build_metadata()
+    table_names = {t.name for t in metadata.sorted_tables}
+    assert table_names == set(DEFAULT_TABLE_NAMES)
+
+
+def test_build_metadata_with_callable_renames_all_tables():
+    metadata = build_metadata(lambda name: f"prefix_{name}")
+    table_names = {t.name for t in metadata.sorted_tables}
+
+    expected = {f"prefix_{name}" for name in DEFAULT_TABLE_NAMES}
+    assert table_names == expected
+
+
+def test_build_metadata_with_dict_renames_only_specified_tables():
+    metadata = build_metadata({"cep_unificado": "my_cep"})
+    table_names = {t.name for t in metadata.sorted_tables}
+
+    assert "my_cep" in table_names
+    assert "cep_unificado" not in table_names
+    assert "log_localidade" in table_names
+
+
+def test_build_metadata_preserves_original_name_in_info():
+    metadata = build_metadata(lambda name: f"prefix_{name}")
+
+    for table in metadata.sorted_tables:
+        assert "original_name" in table.info
+        assert table.name == f"prefix_{table.info['original_name']}"
+
+
+def test_build_metadata_foreign_keys_reference_renamed_tables():
+    metadata = build_metadata(lambda name: f"x_{name}")
+
+    log_bairro = get_table(metadata, "log_bairro")
+    fk_targets = {fk.column.table.name for fk in log_bairro.foreign_keys}
+
+    assert "x_log_localidade" in fk_targets
+    assert "log_localidade" not in fk_targets
+
+
+def test_build_metadata_self_referencing_fk_uses_renamed_table():
+    metadata = build_metadata({"log_localidade": "municipios"})
+
+    log_localidade = get_table(metadata, "log_localidade")
+    assert log_localidade.name == "municipios"
+
+    self_fks = [
+        fk
+        for fk in log_localidade.foreign_keys
+        if fk.column.table.name == log_localidade.name
+    ]
+    assert len(self_fks) == 1
+
+
+# --- get_table ---
+
+
+def test_get_table_finds_by_original_name():
+    metadata = build_metadata({"log_bairro": "bairros"})
+
+    table = get_table(metadata, "log_bairro")
+    assert table.name == "bairros"
+
+
+def test_get_table_raises_for_unknown_original_name():
+    metadata = build_metadata()
+
+    with pytest.raises(KeyError, match="nonexistent"):
+        get_table(metadata, "nonexistent")
+
+
+# --- table_set with custom metadata ---
+
+
+def test_get_cep_tables_with_custom_metadata():
+    metadata = build_metadata(lambda name: f"dne_{name}")
+
+    tables = get_cep_tables(metadata)
+    assert "dne_cep_unificado" in tables
+    assert "cep_unificado" not in tables
+
+
+def test_table_set_to_populate_with_custom_metadata():
+    metadata = build_metadata({"cep_unificado": "my_cep"})
+
+    tables = TableSetEnum.CEP_TABLES.to_populate(metadata)
+    assert "my_cep" in tables
+    assert "cep_unificado" not in tables
+
+
+def test_table_set_to_drop_with_custom_metadata():
+    metadata = build_metadata({"cep_unificado": "my_cep"})
+
+    tables = TableSetEnum.UNIFIED_CEP_ONLY.to_drop(metadata)
+    assert "my_cep" not in tables
+    assert all(t != "my_cep" for t in tables)
+
+
+def test_get_table_files_glob_uses_original_name_for_renamed_tables():
+    metadata = build_metadata({"log_faixa_uf": "faixa_uf"})
+
+    assert get_table_files_glob("faixa_uf", metadata) == "LOG_FAIXA_UF.TXT"
+
+
+def test_get_table_files_glob_preserves_custom_file_glob():
+    metadata = build_metadata({"log_logradouro": "logradouros"})
+
+    assert (
+        get_table_files_glob("logradouros", metadata) == "LOG_LOGRADOURO_*.TXT"
+    )
+
+
+def test_get_table_files_glob_returns_none_for_unified_table():
+    metadata = build_metadata({"cep_unificado": "my_cep"})
+
+    assert get_table_files_glob("my_cep", metadata) is None
+
+
+# --- DneLoader with custom table names ---
+
+
+@pytest.fixture
+def dne_resolver(mocker):
+    mock = mocker.patch(
+        "edne_correios_loader.loader.DneLoader.DneResolver"
+    )
+    mock.return_value.__enter__.return_value = mock.return_value
+    return mock
+
+
+@pytest.fixture
+def db_writer(mocker):
+    mock = mocker.patch(
+        "edne_correios_loader.loader.DneLoader.DneDatabaseWriter"
+    )
+    mock.return_value.__enter__.return_value = mock.return_value
+    return mock
+
+
+def test_loader_with_dict_table_names_uses_custom_metadata(
+    dne_resolver,  # noqa: ARG001
+    db_writer,
+    mocker,
+):
+    mocker.patch("edne_correios_loader.loader.TableFilesReader")
+
+    loader = DneLoader(
+        sentinel.db_url,
+        dne_source=sentinel.dne_source,
+        table_names={"cep_unificado": "my_cep"},
+    )
+
+    assert get_table(loader.metadata, "cep_unificado").name == "my_cep"
+
+    loader.load()
+
+    tables_created = db_writer.return_value.create_tables.call_args[0][0]
+    assert "my_cep" in tables_created
+    assert "cep_unificado" not in tables_created
+
+
+def test_loader_with_callable_table_names_uses_custom_metadata(
+    dne_resolver,  # noqa: ARG001
+    db_writer,
+    mocker,
+):
+    mocker.patch("edne_correios_loader.loader.TableFilesReader")
+
+    loader = DneLoader(
+        sentinel.db_url,
+        dne_source=sentinel.dne_source,
+        table_names=lambda name: f"dne_{name}",
+    )
+
+    assert get_table(loader.metadata, "log_localidade").name == "dne_log_localidade"
+
+    loader.load()
+
+    tables_created = db_writer.return_value.create_tables.call_args[0][0]
+    assert all(t.startswith("dne_") for t in tables_created)
+
+
+def test_loader_without_table_names_uses_defaults(
+    dne_resolver,  # noqa: ARG001
+    db_writer,
+    mocker,
+):
+    mocker.patch("edne_correios_loader.loader.TableFilesReader")
+
+    loader = DneLoader(sentinel.db_url, dne_source=sentinel.dne_source)
+    loader.load()
+
+    tables_created = db_writer.return_value.create_tables.call_args[0][0]
+    assert "cep_unificado" in tables_created
+
+
+# --- CepQuerier with custom table name ---
+
+
+def test_cep_querier_with_custom_table_name(connection_url):
+    custom_metadata = build_metadata({"cep_unificado": "my_cep"})
+    cep_table = get_table(custom_metadata, "cep_unificado")
+
+    cep_data = {
+        "cep": "99999999",
+        "logradouro": None,
+        "complemento": None,
+        "bairro": None,
+        "municipio": "Test City",
+        "municipio_cod_ibge": 123456,
+        "uf": "SP",
+        "nome": None,
+    }
+
+    with sa.create_engine(connection_url).connect() as conn:
+        custom_metadata.create_all(conn, tables=[cep_table])
+        conn.execute(cep_table.insert(), [cep_data])
+        conn.commit()
+
+    querier = CepQuerier(connection_url, cep_table_name="my_cep")
+    assert querier.query("99999999") == cep_data
+
+
+def test_cep_querier_without_custom_table_name_uses_default(
+    connection_url,
+):
+    default_metadata = build_metadata()
+    cep_table = default_metadata.tables["cep_unificado"]
+
+    cep_data = {
+        "cep": "88888888",
+        "logradouro": None,
+        "complemento": None,
+        "bairro": None,
+        "municipio": "Default City",
+        "municipio_cod_ibge": 654321,
+        "uf": "RJ",
+        "nome": None,
+    }
+
+    with sa.create_engine(connection_url).connect() as conn:
+        default_metadata.create_all(conn, tables=[cep_table])
+        conn.execute(cep_table.insert(), [cep_data])
+        conn.commit()
+
+    querier = CepQuerier(connection_url)
+    assert querier.query("88888888") == cep_data

--- a/tests/test_custom_table_names.py
+++ b/tests/test_custom_table_names.py
@@ -150,9 +150,7 @@ def test_get_table_files_glob_uses_original_name_for_renamed_tables():
 def test_get_table_files_glob_preserves_custom_file_glob():
     metadata = build_metadata({"log_logradouro": "logradouros"})
 
-    assert (
-        get_table_files_glob("logradouros", metadata) == "LOG_LOGRADOURO_*.TXT"
-    )
+    assert get_table_files_glob("logradouros", metadata) == "LOG_LOGRADOURO_*.TXT"
 
 
 def test_get_table_files_glob_returns_none_for_unified_table():
@@ -166,18 +164,14 @@ def test_get_table_files_glob_returns_none_for_unified_table():
 
 @pytest.fixture
 def dne_resolver(mocker):
-    mock = mocker.patch(
-        "edne_correios_loader.loader.DneLoader.DneResolver"
-    )
+    mock = mocker.patch("edne_correios_loader.loader.DneLoader.DneResolver")
     mock.return_value.__enter__.return_value = mock.return_value
     return mock
 
 
 @pytest.fixture
 def db_writer(mocker):
-    mock = mocker.patch(
-        "edne_correios_loader.loader.DneLoader.DneDatabaseWriter"
-    )
+    mock = mocker.patch("edne_correios_loader.loader.DneLoader.DneDatabaseWriter")
     mock.return_value.__enter__.return_value = mock.return_value
     return mock
 

--- a/tests/test_dbwriter.py
+++ b/tests/test_dbwriter.py
@@ -3,7 +3,11 @@ import sqlalchemy as sa
 
 from edne_correios_loader import TableSetEnum
 from edne_correios_loader.dbwriter import DneDatabaseWriter
-from edne_correios_loader.tables import log_bairro, log_localidade, log_logradouro
+from edne_correios_loader.tables import get_table, metadata
+
+log_localidade = get_table(metadata, "log_localidade")
+log_bairro = get_table(metadata, "log_bairro")
+log_logradouro = get_table(metadata, "log_logradouro")
 
 
 def reflect_metadata(engine):
@@ -28,8 +32,8 @@ def fetch_all(conn, table):
 @pytest.mark.parametrize(
     "table_set,final_tables",
     (
-        (TableSetEnum.ALL_TABLES, TableSetEnum.ALL_TABLES.to_populate),
-        (TableSetEnum.CEP_TABLES, TableSetEnum.CEP_TABLES.to_populate),
+        (TableSetEnum.ALL_TABLES, TableSetEnum.ALL_TABLES.to_populate()),
+        (TableSetEnum.CEP_TABLES, TableSetEnum.CEP_TABLES.to_populate()),
         (TableSetEnum.UNIFIED_CEP_ONLY, ["cep_unificado"]),
     ),
 )
@@ -44,14 +48,14 @@ def test_dbwriter_create_and_drop_correct_tables(
     external_tables = create_external_tables(engine)
 
     with DneDatabaseWriter(connection_url) as db_writer:
-        db_writer.create_tables(table_set.to_populate)
+        db_writer.create_tables(table_set.to_populate())
 
         reflected_metadata = reflect_metadata(db_writer.engine)
         existing_tables = set(list(reflected_metadata.tables) + external_tables)
 
-        assert existing_tables == set(table_set.to_populate + external_tables)
+        assert existing_tables == set(table_set.to_populate() + external_tables)
 
-        db_writer.drop_tables(table_set.to_drop)
+        db_writer.drop_tables(table_set.to_drop())
         db_writer.connection.commit()
 
         reflected_metadata = reflect_metadata(db_writer.engine)
@@ -65,7 +69,7 @@ def test_dbwriter_rollback_changes_on_error(
     localidades = generate_localidades(10)
 
     with DneDatabaseWriter(connection_url) as db_writer:
-        db_writer.create_tables(TableSetEnum.CEP_TABLES.to_populate)
+        db_writer.create_tables(TableSetEnum.CEP_TABLES.to_populate())
 
         db_writer.populate_table(
             "log_localidade", [stringify_row(row) for row in localidades]
@@ -101,7 +105,7 @@ def test_dbwriter_populate_tables_correctly(
 
     with DneDatabaseWriter(connection_url) as db_writer:
         # test inserting in batches
-        db_writer.create_tables(TableSetEnum.CEP_TABLES.to_populate)
+        db_writer.create_tables(TableSetEnum.CEP_TABLES.to_populate())
 
         db_writer.insert_buffer_size = 10
         db_writer.populate_table(
@@ -140,7 +144,7 @@ def test_dbwriter_is_able_to_populate_tables_with_fk_to_self(
     localidades[3][6] = localidades[0][0]
 
     with DneDatabaseWriter(connection_url) as db_writer:
-        db_writer.create_tables(TableSetEnum.CEP_TABLES.to_populate)
+        db_writer.create_tables(TableSetEnum.CEP_TABLES.to_populate())
 
         db_writer.populate_table(
             "log_localidade", [stringify_row(l) for l in localidades]
@@ -164,7 +168,7 @@ def test_dbwriter_clean_tables_correctly(
 
     with DneDatabaseWriter(connection_url) as db_writer:
         # test inserting in batches
-        db_writer.create_tables(TableSetEnum.CEP_TABLES.to_populate)
+        db_writer.create_tables(TableSetEnum.CEP_TABLES.to_populate())
 
         db_writer.insert_buffer_size = 10
         db_writer.populate_table(
@@ -180,7 +184,7 @@ def test_dbwriter_clean_tables_correctly(
         )
 
     with DneDatabaseWriter(connection_url) as db_writer:
-        db_writer.clean_tables(TableSetEnum.CEP_TABLES.to_populate)
+        db_writer.clean_tables(TableSetEnum.CEP_TABLES.to_populate())
 
     with sa.create_engine(connection_url).connect() as connection:
         assert fetch_all(connection, log_localidade) == []
@@ -195,4 +199,4 @@ def test_dbwriter_calls_populate_unified_table(mocker, connection_url):
 
     with DneDatabaseWriter(connection_url) as db_writer:
         db_writer.populate_unified_table()
-        populate_unified_table.assert_called_once_with(db_writer.connection)
+        populate_unified_table.assert_called_once_with(db_writer.connection, metadata)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -40,14 +40,18 @@ def test_loader_create_populate_and_drop_correct_tables(
 ):
     table_files_reader = mocker.patch("edne_correios_loader.loader.TableFilesReader")
     loader = DneLoader(db_url, dne_source=dne_source)
+
+    tables_to_populate = table_set.to_populate(loader.metadata)
+    tables_to_drop = table_set.to_drop(loader.metadata)
+
     loader.load(table_set=table_set)
 
-    db_writer.return_value.create_tables.assert_called_once_with(table_set.to_populate)
-    db_writer.return_value.drop_tables.assert_called_once_with(table_set.to_drop)
+    db_writer.return_value.create_tables.assert_called_once_with(tables_to_populate)
+    db_writer.return_value.drop_tables.assert_called_once_with(tables_to_drop)
 
     assert db_writer.return_value.populate_table.call_args_list == [
         mocker.call(table_name, table_files_reader.return_value)
-        for table_name in table_set.to_populate
+        for table_name in tables_to_populate
         if table_name != "cep_unificado"
     ]
 

--- a/tests/test_table_set.py
+++ b/tests/test_table_set.py
@@ -77,7 +77,7 @@ def test_get_tables_files_glob():
     ],
 )
 def test_table_set_to_populate(table_set, tables_to_populate):
-    assert table_set.to_populate == tables_to_populate
+    assert table_set.to_populate() == tables_to_populate
 
 
 @pytest.mark.parametrize(
@@ -109,4 +109,4 @@ def test_table_set_to_populate(table_set, tables_to_populate):
     ],
 )
 def test_table_set_to_drop(table_set, tables_to_drop):
-    assert table_set.to_drop == tables_to_drop
+    assert table_set.to_drop() == tables_to_drop

--- a/tests/test_unified_table.py
+++ b/tests/test_unified_table.py
@@ -239,7 +239,7 @@ def test_populate_unified_table_populates_correctly(connection_url):
             table = metadata.tables[table_name]
             connection.execute(table.insert(), rows)
 
-        populate_unified_table(connection, insert_batch_size=2)
+        populate_unified_table(connection, metadata, insert_batch_size=2)
 
         unified_table = metadata.tables["cep_unificado"]
         pks = [c.name for c in unified_table.primary_key]


### PR DESCRIPTION
## Summary

Adds support for customizing database table names, enabling integration with projects that follow specific naming conventions.

- `DneLoader` accepts a new `table_names` parameter (dict or callable) to rename tables at creation time
- `CepQuerier` accepts an optional `cep_table_name` to query a renamed unified CEP table
- CLI `load` command gets `--table-name original=custom` (repeatable) to rename tables
- CLI `query-cep` command gets `--cep-table-name` to query a renamed table
- Static module-level table definitions refactored into a `build_metadata()` factory function
- Full backward compatibility for the Python API — all new parameters are optional with sensible defaults
- `TableSetEnum.to_populate` and `to_drop` changed from properties to methods accepting optional metadata

### README improvements

- New intro highlighting value proposition and one-command setup
- Reorganized structure: Quick Start, What it does, Installation, Usage
- Simplified examples focusing on the primary use case (auto-download from Correios)
- Updated CEP count to 1.5M+